### PR TITLE
fix: ipxe prompt arm64

### DIFF
--- a/ipxe/pkg.yaml
+++ b/ipxe/pkg.yaml
@@ -17,6 +17,14 @@ steps:
         tar -xzf ipxe.tar.gz --strip-components=1
 
         patch -p1 < /pkg/patches/https.patch
+
+        # ref: https://github.com/siderolabs/sidero/issues/806
+        {{ if eq .ARCH "aarch64" }}
+        cat <<EOF > src/config/local/nap.h
+        #undef NAP_EFIARM
+        #define NAP_NULL
+        EOF
+        {{ end }}
     build:
       - |
         cd src/


### PR DESCRIPTION
Fixes iPXE prompt hanging on ARM64

The fix is not added as a patch since `src/config/local` is supposed to
be user fixes added in iPXE and gitignored by the iPXE project

Fixes: https://github.com/siderolabs/sidero/issues/806

Signed-off-by: Noel Georgi <git@frezbo.dev>