### PR TITLE
chore: bump kernel to 5.15.34

### DIFF
--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 5.15.33 Kernel Configuration
+# Linux/x86 5.15.34 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.33 Kernel Configuration
+# Linux/arm64 5.15.34 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/prepare/pkg.yaml
+++ b/kernel/prepare/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - image: '{{ .TOOLS_IMAGE }}'
 steps:
   - sources:
-      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.33.tar.xz
+      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.34.tar.xz
         destination: linux.tar.xz
-        sha256: c30a17e6090f9ebf2d8ff58cd6c92c7324b1f4a8b3aa6a7f68850310af05a9c4
-        sha512: cc70547b90417a11cdd580aecbf703541871e744d9df7547bd155ada8c3023be2bea4671771d40efe71e5476a195a4e1942efe53222016409e4a72ba1cf10e02
+        sha256: a7514685392f0f89b337fa252a10a004c6a97d23e8d1126059c8e373398fdb69
+        sha512: 4417a37ae1c31fadfa1dc311271796f2e4cf7065deafa9e5b2153e5a396c6137196431fa3af33534827c1650b8497649c501268754275d6173c39f2071d47b96
     env:
       ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
     prepare:


### PR DESCRIPTION
Bump kernel to 5.15.34 LTS

Signed-off-by: Noel Georgi <git@frezbo.dev>