### PR TITLE
chore: bump raspberrypi-firmware to 1.20220331

### DIFF
--- a/raspberrypi-firmware/pkg.yaml
+++ b/raspberrypi-firmware/pkg.yaml
@@ -6,10 +6,10 @@ dependencies:
 steps:
 # {{ if eq .ARCH "aarch64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr restricting build to arm64 only
   - sources:
-      - url: https://github.com/raspberrypi/firmware/archive/refs/tags/1.20211029.tar.gz
+      - url: https://github.com/raspberrypi/firmware/archive/refs/tags/1.20220331.tar.gz
         destination: raspberrypi-firmware.tar.gz
-        sha256: 22d0d5d2df73263bd0e6bdcd31c7e0d97ea6c438834e2cfaa51cb958f20b7205
-        sha512: 7a1fe3b1645006c35fa49e842b9ece53b386ece42b8db99649de8d4bc0c19e34b0807767290e26422528606c5847843533aaa0edd0716e9f9f9dcae340a4dce0
+        sha256: e186889be44a80bc148c0a020aaf580633ddb10ee314c1c7299c74fd73db3dd1
+        sha512: c510ddb5eb1c6ea1aa69f0063551445dd21092f68e19b64b885558d2c47735d4e9f781ef9674fbe3a9894d66eb07ccbb004541c9a85005318911fabda899c2cc
     prepare:
       - |
         tar -xzf raspberrypi-firmware.tar.gz --strip-components=1


### PR DESCRIPTION
Bump raspberrypi-firmware to 1.20220331

This allows to use the upstream kernel PoE hat driver

Ref: https://github.com/raspberrypi/firmware/commit/69277bc713133a54a1d20554d79544da1ae2b6ca

Signed-off-by: Noel Georgi <git@frezbo.dev>