### PR TITLE
chore: bump kernel to 5.15.41

### DIFF
--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 5.15.40 Kernel Configuration
+# Linux/x86 5.15.41 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.40 Kernel Configuration
+# Linux/arm64 5.15.41 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/prepare/pkg.yaml
+++ b/kernel/prepare/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - image: '{{ .TOOLS_IMAGE }}'
 steps:
   - sources:
-      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.40.tar.xz
+      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.41.tar.xz
         destination: linux.tar.xz
-        sha256: c787f7eecbabbfca4dd3224827292a5fb98e3370c6e04b859714fba25bb8c33b
-        sha512: 2cd0ef9f0932bf5a2a400a467687937cc5164cedd79ec0cf726921249e1d540a9ecc99cd8edb3e8ee74ebaa7a131dbf19886f5e858bf7834b59779f0d110dbf8
+        sha256: 3c7cb1fc3b029b1b765a33af9608b6f18f734246050640def019ee4c4ad6591e
+        sha512: f93bddc7c7890c5014c0b506884bd5487cddac462f74e965e869538f97e22428739e5f71badfcb6ccb5b20f642dd66b53286d85036d239245cca9865d826044b
     env:
       ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
     prepare:


### PR DESCRIPTION
Bump kernel to 5.15.41 LTS

Signed-off-by: Noel Georgi <git@frezbo.dev>