### PR TITLE
chore: bump nvidia driver to 515.43.04

### DIFF
--- a/nonfree/kmod-nvidia/pkg.yaml
+++ b/nonfree/kmod-nvidia/pkg.yaml
@@ -6,15 +6,15 @@ dependencies:
 steps:
   - sources:
     # {{ if eq .ARCH "aarch64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
-      - url: https://download.nvidia.com/XFree86/Linux-aarch64/510.68.02/NVIDIA-Linux-aarch64-510.68.02.run
+      - url: https://download.nvidia.com/XFree86/Linux-aarch64/515.43.04/NVIDIA-Linux-aarch64-515.43.04.run
         destination: nvidia.run
-        sha256: 6a4aa4418813dd691b8a1cc7e4f24d82175e7be07c38563dffa1485c6be56562
-        sha512: b075e20b8457a1fe16a0ac1f34ff9a94d739673858a9a973c361856e07ab25a56e9ff2856a828866fea00407c5e4a4394d3c7aa6728a9a31bad0905e1d60f002
+        sha256: 96a3bd2c464191f26763f7c82f34b602aa8fb190bf818943c5e6e19fdf50a671
+        sha512: 68a2018c1649558388a0e9dbef698cbd4ceb12fc651f618774d26c7cf1c2733450538c0b11fca0ca7c59a74089dab02a9cfb35e87b7b078cb8411f8835b7b1c2
     # {{ else }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
-      - url: https://download.nvidia.com/XFree86/Linux-x86_64/510.68.02/NVIDIA-Linux-x86_64-510.68.02.run
+      - url: https://download.nvidia.com/XFree86/Linux-x86_64/515.43.04/NVIDIA-Linux-x86_64-515.43.04.run
         destination: nvidia.run
-        sha256: bd2c344ac92b2fc12b06043590a4fe8d4eb0ccb74d0c49352f004cf2d299f4c5
-        sha512: eb31ed729555075bcc307acc576cb6fdfdd7e397c9e47dd80fc2f55cac6902c3924b69bb91036e5ded1001e81d4b81082ba093dd63d6d97bc313fe78e510131b
+        sha256: 3e875a4d350e4b2316f2bb5db5a6c89122ec920cc0ca64327d3a0d970c4f3dc7
+        sha512: 07dfcfc297d8dc3072ddf5d719ab5fe3de0aaa2d9b2b7329d86a1cc167c79bd3854c0644cc0080689e2529b3e375dc3ffb370afc3904362722b338d2c1c2837a
     # {{ end }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
     env:
       ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}


### PR DESCRIPTION
Bump Nvidia driver to 515.43.04

Signed-off-by: Noel Georgi <git@frezbo.dev>