### PR TITLE
feat: azure boot disk defenition

### DIFF
--- a/eudev/files/66-azure.rules
+++ b/eudev/files/66-azure.rules
@@ -1,0 +1,28 @@
+# Original file https://github.com/canonical/cloud-init/blob/main/udev/66-azure-ephemeral.rules
+# Skip all partitions symlinks. It uses by cloud-init (fstab mount paths) only.
+#
+# Azure specific rules
+ACTION=="add|change", SUBSYSTEM=="block", ENV{ID_VENDOR}=="Msft", ENV{ID_MODEL}=="Virtual_Disk", GOTO="azure_disk"
+GOTO="azure_end"
+
+LABEL="azure_disk"
+# Root has a GUID of 0000 as the second value on Gen1 instances
+# The resource/resource has GUID of 0001 as the second value
+ATTRS{device_id}=="?00000000-0000-*", ENV{fabric_name}="root", GOTO="azure_names"
+ATTRS{device_id}=="?00000000-0001-*", ENV{fabric_name}="resource", GOTO="azure_names"
+ATTRS{device_id}=="?00000001-0001-*", ENV{fabric_name}="BEK", GOTO="azure_names"
+
+# Azure well known SCSI controllers on Gen2 instances
+ATTRS{device_id}=="{f8b3781a-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi0", GOTO="azure_datadisk"
+GOTO="azure_end"
+
+# Map scsi#/lun# fabric_name to azure_root|resource on Gen2 instances
+LABEL="azure_datadisk"
+ENV{DEVTYPE}=="disk", ENV{fabric_name}="$env{fabric_scsi_controller}/$env{ID_PATH}", GOTO="azure_names"
+GOTO="azure_end"
+
+# Create the symlinks
+LABEL="azure_names"
+ENV{DEVTYPE}=="disk", SYMLINK+="disk/azure/$env{fabric_name}"
+
+LABEL="azure_end"

--- a/eudev/pkg.yaml
+++ b/eudev/pkg.yaml
@@ -44,6 +44,9 @@ steps:
 
         # cleanup non-relevant rules
         rm -f /rootfs/usr/lib/udev/rules.d/{60-cdrom_id.rules,60-persistent-alsa.rules,60-persistent-v4l.rules,64-btrfs.rules,70-joystick.rules,70-mouse.rules,70-touchpad.rules,78-sound-card.rules,80-net-name-slot.rules}
+
+        # Azure csi support
+        cp /pkg/files/66-azure.rules /rootfs/usr/lib/udev/rules.d/66-azure.rules
 finalize:
   - from: /rootfs
     to: /


### PR DESCRIPTION
Create symlinks root/resource devices to /dev/disk/azure folder.
Currently, Azure CSI uses folder /dev/drive/azure to define the boot/temporary disks.
It helps to find the disk by LUN number (removes the system disks from result).

Signed-off-by: Serge Logvinov <serge.logvinov@sinextra.dev>