### PR TITLE
chore: stable source date epoch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,10 @@ SHA ?= $(shell git describe --match=none --always --abbrev=8 --dirty)
 TAG ?= $(shell git describe --tag --always --dirty)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
-SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
+# inital commit time
+# git rev-list --max-parents=0 HEAD
+# git log ad5ad0a513b775e597c818b25476fc59ba3e4a8c --pretty=%ct
+SOURCE_DATE_EPOCH ?= "1559424892"
 
 BUILD := docker buildx build
 PLATFORM ?= linux/amd64,linux/arm64

--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.1.0-alpha.0-17-g967ebd9
+  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.1.0-alpha.0-18-g50e535a
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/pkgs


### PR DESCRIPTION
Use the timestamp from repo initial commit as `SOURCE_DATE_EPOCH`

Bump to tools built with stable [`SOURCE_DATE_EPOCH`](https://github.com/siderolabs/tools/pull/198)

Signed-off-by: Noel Georgi <git@frezbo.dev>