### PR TITLE
feat: update Flannel CNI to 1.1.0

### DIFF
--- a/flannel-cni/pkg.yaml
+++ b/flannel-cni/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://github.com/flannel-io/cni-plugin/archive/refs/tags/v1.0.1.tar.gz
+      - url: https://github.com/flannel-io/cni-plugin/archive/refs/tags/v1.1.0.tar.gz
         destination: flannel-cni.tar.gz
-        sha256: 8f7ad32355bc54b3c736c15f66613b6a1eb87a5b8d1bdd201f7b6a1cd68a7442
-        sha512: 88e8b6a0c57815af37528f80474e93302274d2d4731e6f52f2f7fff142e13c8f4dfe425424f9869ecf54687f3daf750dcf194d550fc938dd4ae74b0d94cb224d
+        sha256: 2bd79d899e8a8b3f96bf267ed2d7d5a0da3df45d8581cbf8d9e8433692375ae7
+        sha512: e026bed01f8ac64b584d8c438ccc048df607b2e4832493335b2e266166acebf32f2b58c353bc2ecd3750d920e65a79afef7b28bf4a6405e2f461ab2c8cd953a7
     env:
       GOPATH: /go
     prepare:


### PR DESCRIPTION
See https://github.com/flannel-io/cni-plugin/releases/tag/v1.1.0

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>