### PR TITLE
chore: bump tools to final v1.1.0 release

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.1.0-alpha.0-18-g50e535a
+  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.1.0
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/pkgs


### PR DESCRIPTION
In preparation for Talos 1.1.0-beta release.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>