### PR TITLE
chore: bump golang to 1.18.3

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.1.0
+  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.2.0-alpha.0
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/pkgs


### PR DESCRIPTION
Bump golang to [1.18.3](https://github.com/siderolabs/tools/pull/200)

Signed-off-by: Noel Georgi <git@frezbo.dev>