### PR TITLE
chore: bump kernel to 5.15.46

### DIFF
--- a/kernel/prepare/pkg.yaml
+++ b/kernel/prepare/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - image: '{{ .TOOLS_IMAGE }}'
 steps:
   - sources:
-      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.45.tar.xz
+      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.46.tar.xz
         destination: linux.tar.xz
-        sha256: b2390d7d977c66036ef0ceb294e408f2bdaab6dfeeb8ff4f4e0a84b71f8d8754
-        sha512: 0a8e95cf04af68fffa3dfa23dd53e897527c8c574c91cc0601856a5cf25aec077911405bccf85307d3da51c5152a3f7daa99b6373d8d90124224530221cfc66c
+        sha256: eb455746779bb79533e6c1afcd0d5e8ad2295898b786f47d718f087a3d07376b
+        sha512: aed8ee53e8d70f4110db49fd6ceae4b4664855a4694c9abd2064057e04efcdf22e09f6883269bf383ac700b4217333e9bbdb3f4aaf839e9e479d6360b637fc2c
     env:
       ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
     prepare:


### PR DESCRIPTION
Bump kernel to 5.15.46

Signed-off-by: Noel Georgi <git@frezbo.dev>