### PR TITLE
chore: bump kernel to 5.15.49

### DIFF
--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 5.15.48 Kernel Configuration
+# Linux/x86 5.15.49 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y
@@ -3081,7 +3081,7 @@ CONFIG_TCG_CRB=y
 # CONFIG_XILLYBUS is not set
 # CONFIG_XILLYUSB is not set
 CONFIG_RANDOM_TRUST_CPU=y
-# CONFIG_RANDOM_TRUST_BOOTLOADER is not set
+CONFIG_RANDOM_TRUST_BOOTLOADER=y
 # end of Character devices
 
 #
@@ -5379,6 +5379,7 @@ CONFIG_CRYPTO_LIB_CHACHA20POLY1305=y
 CONFIG_CRYPTO_LIB_SHA256=y
 # end of Crypto library routines
 
+CONFIG_LIB_MEMNEQ=y
 CONFIG_CRC_CCITT=y
 CONFIG_CRC16=y
 # CONFIG_CRC_T10DIF is not set

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.48 Kernel Configuration
+# Linux/arm64 5.15.49 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y
@@ -3584,7 +3584,7 @@ CONFIG_TCG_CRB=y
 # CONFIG_XILLYBUS is not set
 # CONFIG_XILLYUSB is not set
 CONFIG_RANDOM_TRUST_CPU=y
-# CONFIG_RANDOM_TRUST_BOOTLOADER is not set
+CONFIG_RANDOM_TRUST_BOOTLOADER=y
 # end of Character devices
 
 #
@@ -7792,6 +7792,7 @@ CONFIG_CRYPTO_LIB_SHA256=y
 CONFIG_CRYPTO_LIB_SM4=y
 # end of Crypto library routines
 
+CONFIG_LIB_MEMNEQ=y
 CONFIG_CRC_CCITT=y
 CONFIG_CRC16=y
 CONFIG_CRC_T10DIF=y

--- a/kernel/prepare/pkg.yaml
+++ b/kernel/prepare/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - image: '{{ .TOOLS_IMAGE }}'
 steps:
   - sources:
-      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.48.tar.xz
+      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.49.tar.xz
         destination: linux.tar.xz
-        sha256: 19f0075d1b94d6874a2af7127a59b6b6c423fc7d4a883a51415543e7ec1be2a6
-        sha512: 6eee3ff3352a864a5d98295527056da0d6d52b5f566fd7858b2e12a5d0094efea0af484a7e8cdcb344bba343c5d95b5d19c0d2756dd3f38531712438223755b6
+        sha256: 32497893ba47f4ad32a59fa4254e8c25e41bc821798e3b2f2443822fa00059dc
+        sha512: 50df71d9cbc2be09348d89a89f50543e9022c88b71ace9e93274aa49530825980661ead4cbe726a3ee899b6965d16b1bd1324e754d9b546eb8d8ad6232250caf
     env:
       ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
     prepare:


### PR DESCRIPTION
Bump kernel to 5.15.49 LTS


Enable `RANDOM_TRUST_BOOTLOADER` by default

Ref: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=846bb97e131d7938847963cca00657c995b1fce1

Signed-off-by: Noel Georgi <git@frezbo.dev>