### PR TITLE
chore: bump kernel to 5.15.52

### DIFF
--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 5.15.51 Kernel Configuration
+# Linux/x86 5.15.52 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.51 Kernel Configuration
+# Linux/arm64 5.15.52 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/prepare/pkg.yaml
+++ b/kernel/prepare/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - image: '{{ .TOOLS_IMAGE }}'
 steps:
   - sources:
-      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.51.tar.xz
+      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.52.tar.xz
         destination: linux.tar.xz
-        sha256: 1fba4878b27ef4fd9005e0870cb7aa7c4a051b66575cab102d36184b32a94988
-        sha512: 8ae5627cdc20989e29a2ee97b9df0eb660a1e16be9c9f2fcbb2654b3e2cfbbc2ead02403b5917f6fa7cd7f83e3508e898415b079cbbdbfcff1ffa87d6c4511b7
+        sha256: f4680a5da9f25a908ead5956935e7c05124d5f37f6e75a1e07d58641d7ab6d05
+        sha512: 01852559b30b177ba350827b076dc58ecad020e63940482e694286ade3debe53919a4514338536f46da1aa4f89b671368a112a913a53a0352d033252bc6b2a1b
     env:
       ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
     prepare:


### PR DESCRIPTION
Bump kernel to 5.15.52

Signed-off-by: Noel Georgi <git@frezbo.dev>