### PR TITLE
chore: bump kernel to 5.15.53

### DIFF
--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 5.15.52 Kernel Configuration
+# Linux/x86 5.15.53 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.52 Kernel Configuration
+# Linux/arm64 5.15.53 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/prepare/pkg.yaml
+++ b/kernel/prepare/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - image: '{{ .TOOLS_IMAGE }}'
 steps:
   - sources:
-      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.52.tar.xz
+      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.53.tar.xz
         destination: linux.tar.xz
-        sha256: f4680a5da9f25a908ead5956935e7c05124d5f37f6e75a1e07d58641d7ab6d05
-        sha512: 01852559b30b177ba350827b076dc58ecad020e63940482e694286ade3debe53919a4514338536f46da1aa4f89b671368a112a913a53a0352d033252bc6b2a1b
+        sha256: f3aa717243051f3fcca90ebfe26fe5c3a596c2f6047846e8d1724ea90df77b07
+        sha512: 7a147bec74a8c390e24f5d61b34ce6f20c3d0f363f45f0bddf11da35aee035648d3ec71fffde01d47b56c49547c3b33cb22e987830b0acec38a90d78cffe25f2
     env:
       ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
     prepare:


### PR DESCRIPTION
Bump kernel to 5.15.53

Signed-off-by: Noel Georgi <git@frezbo.dev>