### PR TITLE
backport: chore: update Go to 1.18.4

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.1.0-1-g134974c
+  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.1.0-2-g9edfc1f
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/pkgs


### PR DESCRIPTION
See https://github.com/siderolabs/tools/pull/208

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>