### PR TITLE
chore: bump kernel to 5.15.58

### DIFF
--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 5.15.57 Kernel Configuration
+# Linux/x86 5.15.58 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.57 Kernel Configuration
+# Linux/arm64 5.15.58 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/prepare/pkg.yaml
+++ b/kernel/prepare/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - image: '{{ .TOOLS_IMAGE }}'
 steps:
   - sources:
-      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.57.tar.xz
+      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.58.tar.xz
         destination: linux.tar.xz
-        sha256: 62e3095a1fc876315150c93aad1546cc198e3ba5863b3d7ff7da21fbee20f0fd
-        sha512: d14968b0fc7f4c3162c2c7975367e5c685675e29515a82d3010bc49a124e761beb90eabb7f0e2823e2afb32c0110df887440966dbf37c29247479d5009905d5b
+        sha256: d75bd9579c4b318e6162e21c591878fd37efda0f79c5cdd0dc4eb9ea9dfc4fa8
+        sha512: b0474dc0c8e7e1bfc45e22f5df3c435066ad69144fc4b451335e43133c2113f3d3c1f7c2f3df6e54539fb6d87ebb16f069907c1f4e5922bb69a07e2a00463110
     env:
       ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
     prepare:


### PR DESCRIPTION
Bump kernel to 5.15.58

Signed-off-by: Noel Georgi <git@frezbo.dev>