### PR TITLE
chore: bump containerd to v1.6.8

### DIFF
--- a/containerd/pkg.yaml
+++ b/containerd/pkg.yaml
@@ -7,10 +7,10 @@ dependencies:
 steps:
   - sources:
         # sync with version and revision in build
-      - url: https://github.com/containerd/containerd/archive/refs/tags/v1.6.7.tar.gz
+      - url: https://github.com/containerd/containerd/archive/refs/tags/v1.6.8.tar.gz
         destination: containerd.tar.gz
-        sha256: 710fe5c745d4f2a405a719645cc6aba8b3cbf2b75f58ad33e673cd945a1c78ca
-        sha512: 38c933e6c230003f992c58f1aa2cca71ecce2087dfe855ea4e30668f219aeb9f7f99ff5abc516326b4764bdf358681ce901d7bc86dd7847b599d1a9c3381fae2
+        sha256: f5f938513c28377f64f85e84f2750d39f26b01262f3a062b7e8ce35b560ca407
+        sha512: c204c028cdfd76537d1da01c66526fc85b29b02d2412569bb9b265375603614b037356c61846025a72281398f0f46df326a5ea3df97f57901cce85f2f728f0ba
     prepare:
       - |
         tar -xzf containerd.tar.gz --strip-components=1
@@ -22,7 +22,7 @@ steps:
         export CGO_ENABLED=1
         export PATH=${PATH}:${TOOLCHAIN}/go/bin
         export BUILDTAGS='seccomp no_aufs no_btrfs no_devmapper no_zfs'
-        make bin/containerd bin/containerd-shim bin/containerd-shim-runc-v2 VERSION=v1.6.7 REVISION=0197261a30bf81f1ee8e6a4dd2dea0ef95d67ccb
+        make bin/containerd bin/containerd-shim bin/containerd-shim-runc-v2 VERSION=v1.6.7 REVISION=9cd3357b7fd7218e4aec3eae239db1f68a5a6ec6
     install:
       - |
         mkdir -p /rootfs/bin


### PR DESCRIPTION
Bump containerd to [v1.6.8](https://github.com/containerd/containerd/releases/tag/v1.6.8)

Signed-off-by: Noel Georgi <git@frezbo.dev>