### PR TITLE
chore: bump gcc to 12.1.0

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.2.0
+  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.3.0-alpha.0-1-g7d6f9c3
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/pkgs

--- a/ipxe/patches/silence-gcc-12-spurious-warnings.patch
+++ b/ipxe/patches/silence-gcc-12-spurious-warnings.patch
@@ -1,0 +1,25 @@
+diff --git a/roms/ipxe/src/Makefile.housekeeping b/roms/ipxe/src/Makefile.housekeeping
+index 134becd50..4b0aa9e96 100644
+--- a/roms/ipxe/src/Makefile.housekeeping
++++ b/roms/ipxe/src/Makefile.housekeeping
+@@ -183,6 +183,20 @@ WNAPM_TEST = $(CC) -Wno-address-of-packed-member -x c -c /dev/null \
+ WNAPM_FLAGS := $(shell $(WNAPM_TEST) && \
+ 		 $(ECHO) '-Wno-address-of-packed-member')
+ WORKAROUND_CFLAGS += $(WNAPM_FLAGS)
++
++# gcc 12.1 generates false positive warnings.  Inhibit the warnings.
++WNAB_TEST = $(CC) -Wno-array-bounds -x c -c /dev/null \
++		   -o /dev/null >/dev/null 2>&1
++WNAB_FLAGS := $(shell $(WNAB_TEST) && \
++		 $(ECHO) '-Wno-array-bounds')
++WORKAROUND_CFLAGS += $(WNAB_FLAGS)
++
++WNDP_TEST = $(CC) -Wno-dangling-pointer-x c -c /dev/null \
++		   -o /dev/null >/dev/null 2>&1
++WNDP_FLAGS := $(shell $(WNAB_TEST) && \
++		 $(ECHO) '-Wno-dangling-pointer')
++WORKAROUND_CFLAGS += $(WNDP_FLAGS)
++
+ endif
+ 
+ # Some versions of gas choke on division operators, treating them as

--- a/ipxe/pkg.yaml
+++ b/ipxe/pkg.yaml
@@ -6,17 +6,20 @@ dependencies:
   - stage: liblzma
 steps:
   - sources:
-      - url: https://github.com/ipxe/ipxe/archive/9062544f6a0c69c249b90d21a08d05518aafc2ec.tar.gz
+      - url: https://github.com/ipxe/ipxe/archive/c5af41a6f5b5f4a420b3e539f9e3a8dc9f8dd03e.tar.gz
         destination: ipxe.tar.gz
-        sha256: f27c02b9e9a4b2af521fd62e7d47bee3433c8edb75b4b2d0ddcd55848e353b96
-        sha512: 87aa803dbe8265bd5b5be989e32ffef50032c3e4783ca4d3f95dfaa707d8bdecab723e0b582ab6fa7e2cd8d40b55be67ecbddadd8d0f752c143bc8be3e658fcb
+        sha256: 370ef608f6314fe53bef52f780288364aa446428eb774c1cd55c656b81fe23b8
+        sha512: 4aa202b8b9489b217c8ef66b8cb3a8179689e98f2807024246d022eadc311f842855d19f20430bdbeb2358aca6ee7c9533d3f60456ba3b1681a8a22f31c2aa50
     env:
-      IPXE_VERSION: 1.21.1+git+9062544+sidero
+      IPXE_VERSION: 1.21.1+git+c5af41a+sidero
     prepare:
       - |
+        ln -s /toolchain/bin/echo /bin/echo
         tar -xzf ipxe.tar.gz --strip-components=1
 
         patch -p1 < /pkg/patches/https.patch
+        # TODO: remove once ipxe release compiles file on gcc-12
+        patch -p3 < /pkg/patches/silence-gcc-12-spurious-warnings.patch
 
         # ref: https://github.com/siderolabs/sidero/issues/806
         {{ if eq .ARCH "aarch64" }}

--- a/musl/pkg.yaml
+++ b/musl/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - image: "{{ .TOOLS_IMAGE }}"
 steps:
   - sources:
-      - url: https://www.musl-libc.org/releases/musl-1.2.2.tar.gz
+      - url: https://www.musl-libc.org/releases/musl-1.2.3.tar.gz
         destination: musl.tar.gz
-        sha256: 9b969322012d796dc23dda27a35866034fa67d8fb67e0e2c45c913c3d43219dd
-        sha512: 5344b581bd6463d71af8c13e91792fa51f25a96a1ecbea81e42664b63d90b325aeb421dfbc8c22e187397ca08e84d9296a0c0c299ba04fa2b751d6864914bd82
+        sha256: 7d5b0b6062521e4627e099e4c9dc8248d32a30285e959b7eecaa780cf8cfd4a4
+        sha512: 9332f713d3eb7de4369bc0327d99252275ee52abf523ee34b894b24a387f67579787f7c72a46cf652e090cffdb0bc3719a4e7b84dca66890b6a37f12e8ad089c
     prepare:
       - |
         export PATH=${TOOLCHAIN}/cross/bin:${PATH}

--- a/u-boot/arm-trusted-firmware/patches/gcc-12-build-fix.patch
+++ b/u-boot/arm-trusted-firmware/patches/gcc-12-build-fix.patch
@@ -1,0 +1,14 @@
+diff --git Makefile Makefile
+index 3941f8698..ad70d4b7f 100644
+--- Makefile
++++ Makefile
+@@ -390,7 +390,7 @@ ifneq (${E},0)
+ ERRORS := -Werror
+ endif
+ 
+-CPPFLAGS		=	${DEFINES} ${INCLUDES} ${MBEDTLS_INC} -nostdinc	\
++CPPFLAGS		=	${DEFINES} ${INCLUDES} ${MBEDTLS_INC} -nostdinc -Wno-array-bounds \
+ 				$(ERRORS) $(WARNINGS)
+ ASFLAGS			+=	$(CPPFLAGS) $(ASFLAGS_$(ARCH))			\
+ 				-ffreestanding -Wa,--fatal-warnings
+

--- a/u-boot/pkg.yaml
+++ b/u-boot/pkg.yaml
@@ -17,10 +17,10 @@ dependencies:
 steps:
   # {{ if eq .ARCH "aarch64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr restricting build to arm64 only
   - sources:
-      - url: https://github.com/ARM-software/arm-trusted-firmware/archive/v2.6.tar.gz
+      - url: https://github.com/ARM-software/arm-trusted-firmware/archive/v2.7.tar.gz
         destination: arm-trusted-firmware.tar.gz
-        sha256: 3905a6d6affa84fb629d1565a4e4bdc82812bba49a457b8249ab445eeb28011b
-        sha512: 8b20964b1b672898268e27424984af0ef9e95b38f426370ed4b802f67fc204db5f467886707dce77e4560548e01777a6c36d4eb801842c7d1f2ff6ca5d9b7dd1
+        sha256: 327c65b1bc231608a7a808b068b00c1a22310e9fc86158813cd10a9711d5725e
+        sha512: ff9bd87bf74653275ef9abdf2079974c214e13bd1861bdb3dc4240bdf7e972f3a91c8c6ef86e26afcffe51b29b856c8cf6ffb3d4150d7ccd6a4d3b696bb6f55f
       - url: https://ftp.denx.de/pub/u-boot/u-boot-2022.04.tar.bz2
         destination: u-boot.tar.bz2
         sha256: 68e065413926778e276ec3abd28bb32fa82abaa4a6898d570c1f48fbdb08bcd0
@@ -162,6 +162,8 @@ steps:
       # rpi_4_arm-trusted-firmware
       - |
         cd ${RPI_4_A64_ARM_TRUSTED_FIRMWARE}
+        # TODO: remove once ATF compiles fine on gcc 12
+        patch -p0 < /pkg/arm-trusted-firmware/patches/gcc-12-build-fix.patch
         make realclean
         make -j $(nproc) PLAT=rpi4 DEBUG=0 bl31
       # rpi_4


### PR DESCRIPTION
Bump gcc to [12.2.0](https://github.com/siderolabs/tools/pull/214)
Bump musl to 1.2.3
    
Bump ipxe and apply fix for building ipxe with gcc 12, ref:
 - https://github.com/ipxe/ipxe/issues/620
 - https://github.com/openSUSE/qemu-ipxe/commit/1dcf6506629ae
    
Bump ARM trusted firmware to v2.7 and add similar patch like ipxe

Signed-off-by: Noel Georgi <git@frezbo.dev>