### PR TITLE
fix: nvidia oss pkg name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ TARGETS = \
 	linux-firmware \
 	lvm2 \
 	musl \
-	nvidia-open-gpu-kernel-modules \
+	nvidia-open-gpu-kernel-modules-pkg \
 	open-iscsi \
 	open-isns \
 	openssl \

--- a/nvidia-open-gpu-kernel-modules/pkg.yaml
+++ b/nvidia-open-gpu-kernel-modules/pkg.yaml
@@ -1,4 +1,4 @@
-name: nvidia-open-gpu-kernel-modules
+name: nvidia-open-gpu-kernel-modules-pkg
 variant: scratch
 shell: /toolchain/bin/bash
 dependencies:


### PR DESCRIPTION
Fix conflicting `pkg` and `extensions` image name.

Signed-off-by: Noel Georgi <git@frezbo.dev>