### PR TITLE
feat: add 'drbd' package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ TARGETS = \
 	containerd \
 	cryptsetup \
 	dosfstools \
+	drbd \
 	eudev \
 	fhs \
 	flannel-cni \

--- a/Pkgfile
+++ b/Pkgfile
@@ -26,6 +26,11 @@ vars:
   dosfstools_sha256: 64926eebf90092dca21b14259a5301b7b98e7b1943e8a201c7d726084809b527
   dosfstools_sha512: 3cc0808edb4432428df8a67da4bb314fd1f27adc4a05754c1a492091741a7b6875ebd9f6a509cc4c5ad85643fc40395b6e0cadee548b25cc439cc9b725980156
 
+  # renovate: datasource=github-tags extractVersion=^drbd-(?<version>.*)$ depName=LINBIT/drbd
+  drbd_version: 9.1.8
+  drbd_sha256: 6742fbcedac0c75d84a4bcea3832723c98e7d515824a431108ec9d82d58cdee3
+  drbd_sha512: da5aed1ab98b819cc0cf8b4e27be93fedfc91d06eb43e968ca317f3460d2a51a9a8c64b86b326fe090cc65a4347fbfbdd7f498fcecc1db3a92fdf828b4086242
+
   # renovate: datasource=github-releases depName=eudev-project/eudev
   eudev_version: v3.2.11
   eudev_sha256: dcfc482099f3fdfcfdb9aeabbc4d609877cf4d2d0407f50ab0c59d43fff44f92

--- a/drbd/pkg.yaml
+++ b/drbd/pkg.yaml
@@ -1,0 +1,32 @@
+name: drbd
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: kernel-build
+steps:
+  - sources:
+      - url: https://pkg.linbit.com//downloads/drbd/{{ regexReplaceAll ".\\d+\\.\\d+$" .drbd_version "${1}" }}/drbd-{{ .drbd_version }}.tar.gz
+        destination: drbd.tar.gz
+        sha256: "{{ .drbd_sha256 }}"
+        sha512: "{{ .drbd_sha512 }}"
+    env:
+      ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
+    prepare:
+      - |
+        tar -xzf drbd.tar.gz --strip-components=1
+    build:
+      - |
+        make -j $(nproc) -C drbd KERNEL_SOURCES=/src MODVERSIONS=detect KDIR=/src
+    install:
+      - |
+        mkdir -p /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
+        touch /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/modules.order /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/modules.builtin
+
+        make -j $(nproc) -C /src M=$(pwd)/drbd modules_install DESTDIR=/rootfs INSTALL_MOD_PATH=/rootfs CONFIG_MODULE_SIG_ALL=y
+    test:
+      - |
+        # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping
+        find /rootfs/lib/modules -name '*.ko' -exec grep -FL '~Module signature appended~' {} \+
+finalize:
+  - from: /rootfs
+    to: /


### PR DESCRIPTION
I have currently issues with caching in my build environment, so I was not able to test it end-to-end (with installer image). While fixing my environment, I would like to provide everything, what I hava so far...

Would be great if, someone with an ARM system could test it!

A possible use (and test) case is installation of [piraeus-operator](https://github.com/piraeusdatastore/piraeus-operator) following command for helm:
```
helm install \
  --set operator.satelliteSet.kernelModuleInjectionMode=None \
  --set etcd.enabled=false \
  --set controller.dbConnectionURL=k8s \
  piraeus-op \
  ./charts/piraeus
```