### PR TITLE
chore: bump kernel to 5.15.64

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -57,9 +57,9 @@ vars:
   ipxe_sha512: 4aa202b8b9489b217c8ef66b8cb3a8179689e98f2807024246d022eadc311f842855d19f20430bdbeb2358aca6ee7c9533d3f60456ba3b1681a8a22f31c2aa50
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 5.15.63
-  linux_sha256: 6dd3cd1e5a629d0002bc6c6ec7e8ea96710104f38664122dd56c83dfd4eb7341
-  linux_sha512: a1b33476484b9ca7a105d07b70835ad7e7e670750e6beb428ce23fe1bd853d66cd8a1ffca9ee736a98a42b98191d290127e628d33118be971c661e2fc6faf8ca
+  linux_version: 5.15.64
+  linux_sha256: c6a1d38c6fa3798341372d5cf0088ae806ccdc827e31ecbff8988e097ba5de50
+  linux_sha512: 3445baa4f53ab8108af576ca06596071cb12be7d67d93899c0819fa2feae4fff551e702a91357f798f920a0f7fd6cd38f2c1cb66cf60b6cc10142e503fe21b85
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ versioning=loose depName=git://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git
   kmod_version: 27

--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 5.15.63 Kernel Configuration
+# Linux/x86 5.15.64 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 12.2.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.63 Kernel Configuration
+# Linux/arm64 5.15.64 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 12.2.0"
 CONFIG_CC_IS_GCC=y


### PR DESCRIPTION
Bump kernel to 5.15.64

Fixes: CVE-2022-2905

Signed-off-by: Noel Georgi <git@frezbo.dev>