### PR TITLE
feat: added gasket driver package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ TARGETS = \
 	eudev \
 	fhs \
 	flannel-cni \
+	gasket-driver-pkg \
 	grub \
 	ipmitool \
 	iptables \

--- a/Pkgfile
+++ b/Pkgfile
@@ -37,6 +37,11 @@ vars:
   flannel_cni_sha256: 2bd79d899e8a8b3f96bf267ed2d7d5a0da3df45d8581cbf8d9e8433692375ae7
   flannel_cni_sha512: e026bed01f8ac64b584d8c438ccc048df607b2e4832493335b2e266166acebf32f2b58c353bc2ecd3750d920e65a79afef7b28bf4a6405e2f461ab2c8cd953a7
 
+  # renovate: datasource=git-refs versioning=git depName=https://github.com/google/gasket-driver.git
+  gasket_driver_ref: 97aeba584efd18983850c36dcf7384b0185284b3
+  gasket_driver_sha256: df60528df13fbbc01a52d4bb10248ce262bc531484df42aa070b464b566081cb
+  gasket_driver_sha512: 059185a7e1fe7674027d0fd1a9fd3b6390e814382be4ae5d7b4c4c71b0d0e37551b20a8c633b1cf532b0a09197685538dcfc08d08fed867b9d1b314b1bdd1b60
+
   # renovate: datasource=git-tags extractVersion=^grub-(?<version>.*)$ versioning=loose depName=git://git.savannah.gnu.org/grub.git
   grub_version: 2.06
   grub_sha256: b79ea44af91b93d17cd3fe80bdae6ed43770678a9a5ae192ccea803ebb657ee1

--- a/gasket-driver/pkg.yaml
+++ b/gasket-driver/pkg.yaml
@@ -1,0 +1,37 @@
+name: gasket-driver-pkg
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: kernel-build
+steps:
+  - sources:
+      - url: https://github.com/google/gasket-driver/archive/{{ .gasket_driver_ref }}.tar.gz
+        destination: gasket-driver.tar.gz
+        sha256: "{{ .gasket_driver_sha256 }}"
+        sha512: "{{ .gasket_driver_sha512 }}"
+    env:
+      ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
+    prepare:
+      - |
+        tar xf gasket-driver.tar.gz --strip-components=1
+    build:
+      - |
+        cd src
+        sed -i 's|/lib/modules/$(KVERSION)/build|/src|' ./Makefile
+        make all
+
+    install:
+      - |
+        mkdir -p /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
+
+        # create these so we don't get warnings when depmod runs
+        touch /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/modules.order /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/modules.builtin
+
+        make -C /src M=$(pwd)/src modules_install INSTALL_MOD_PATH=/rootfs
+    test:
+      - |
+        # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping
+        find /rootfs/lib/modules -name '*.ko' -exec grep -FL '~Module signature appended~' {} \+
+finalize:
+  - from: /rootfs
+    to: /

--- a/test/pkg.yaml
+++ b/test/pkg.yaml
@@ -11,6 +11,7 @@ dependencies:
   - stage: eudev
   - stage: fhs
   - stage: flannel-cni
+  # - stage: gasket-driver-pkg
   - stage: grub
   - stage: ipmitool
   - stage: iptables


### PR DESCRIPTION
This driver enables the use of [Coral.ai](https://coral.ai/)'s PCIe TPU modules.

Signed-off-by: Branden Cash <203336+ammmze@users.noreply.github.com>

Required-by: siderolabs/extensions#69