### PR TITLE
fix: rollback xfsprogs to 5.18.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -38,6 +38,12 @@
         },
         {
             "matchPackageNames": [
+                "git://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git"
+            ],
+            "allowedVersions": "< 5.19.0"
+        },
+        {
+            "matchPackageNames": [
                 "ipmitool/ipmitool",
                 "git://sourceware.org/git/lvm2.git"
             ],

--- a/Pkgfile
+++ b/Pkgfile
@@ -169,8 +169,8 @@ vars:
   util_linux_sha512: 07f11147f67dfc6c8bc766dfc83266054e6ede776feada0566b447d13276b6882ee85c6fe53e8d94a17c03332106fc0549deca3cf5f2e92dda554e9bc0551957
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git
-  xfsprogs_version: 5.19.0
-  xfsprogs_sha256: 4b6c6c98c036a37f6d90c82cb7fe9405d3b5856d9345662032d01ff4b140592c
-  xfsprogs_sha512: 0b069cd44eb87052ee55ebffcce736ef103adeda539e854bd86d53942f541c07d74cc174f06a2221230eaa82b21d43327833492cd0ded577d442e1935a0abe7d
+  xfsprogs_version: 5.18.0
+  xfsprogs_sha256: 1e8d8801bdec8cd4cad360ce3bbd12c35a97f2bc8f7c8c9580d1903b0e8cc35b
+  xfsprogs_sha512: 47d035a33367edae7357e34c70bdb0fe9219231153fb4c4f418ed1462d137dd77338c12a199eb71cd70e88903e5fc11e1e4fb595c622183786e87346e2f65739
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/pkgs


### PR DESCRIPTION
Rollback xfsprogs to 5.18.0.

Talos [state partition](https://github.com/siderolabs/talos/blob/main/internal/pkg/partition/constants.go#L37) uses a 100MiB partition size of xfs type. Since xfsprogs 5.19.0 paritions of size less than 300MiB are not allowed. For now it doesn't make sense to increase the Talos `STATE` partition size from 100MiB to 300MiB just to make it work with newer xfsprogs. Until Talos has a use case for larger `STATE` partition or a different filesystem type for `STATE` partition, keep xfsprogs locked to `< 5.19.0` allowing minor fixes if any.

Ref: https://fossies.org/linux/xfsprogs/doc/CHANGES

From the xfsprogs [code](https://fossies.org/linux/xfsprogs/mkfs/xfs_mkfs.c):

```text
 2523     /*
 2524      * We don't support filesystems smaller than 300MB anymore.  Tiny
 2525      * filesystems have never been XFS' design target.  This limit has been
 2526      * carefully calculated to prevent formatting with a log smaller than
 2527      * the "realistic" size.
 2528      *
 2529      * If the realistic log size is 64MB, there are four AGs, and the log
 2530      * AG should be at least 1/8 free after formatting, this gives us:
 2531      *
 2532      * 64MB * (8 / 7) * 4 = 293MB
 2533      */
```

Signed-off-by: Noel Georgi <git@frezbo.dev>