### PR TITLE
chore: disable drone slack pipeline for renovate

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -121,9 +121,10 @@ steps:
         - failure
 
 trigger:
-  status:
-    - success
-    - failure
+  branch:
+    exclude:
+      - renovate/*
+      - dependabot/*
 
 depends_on:
   - default

--- a/Pkgfile
+++ b/Pkgfile
@@ -58,9 +58,9 @@ vars:
   iptables_sha512: f21df23279a77531a23f3fcb1b8f0f8ec0c726bda236dd0e33af74b06753baff6ce3f26fb9fcceb6fada560656ba901e68fc6452eb840ac1b206bc4654950f59
 
   # renovate: datasource=git-refs versioning=git depName=https://github.com/ipxe/ipxe.git
-  ipxe_ref: 8f5fc161436a020ba65d07f91f62d34f4c22db61
-  ipxe_sha256: d98fd8fc997637b2b7292df00e73240a63693851fdaf95811c094c4b295bde20
-  ipxe_sha512: 8e1ef8948a1b0337fecd64bf73b06c012cf51fc6cf7f32ee39fc0f2671130e18ebee66271bc1c4451a201d1c931a2dc345172a6ce98e94151cf01fccd0115d71
+  ipxe_ref: 649176cd608e74ce54d20488a0618b4c6d8be71d
+  ipxe_sha256: eaee2e848d36f486c87c4b13b2a58e0a140139319340203c1c489316e3d3a007
+  ipxe_sha512: ef724cef6edb28d32df795a41978d5c2e25bb34143aa8d28d0d3950b82dbaefb3c36740edff9af51d01377b27a3be1e77f204678c7cbf19c32b545ff594bb57e
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
   linux_version: 5.15.68


### PR DESCRIPTION
The slack trigger was already having status set in the step itself, so remove that and only use the trigger.

Signed-off-by: Noel Georgi <git@frezbo.dev>