### PR TITLE
chore: use generic raspberry pi u-boot

### DIFF
--- a/u-boot/pkg.yaml
+++ b/u-boot/pkg.yaml
@@ -8,6 +8,8 @@
 #     - http://opensource.rock-chips.com
 #     - https://github.com/u-boot/u-boot/blob/master/doc/board/rockchip/rockchip.rst
 #     - https://u-boot.readthedocs.io/en/latest/board/rockchip/rockchip.html
+#   Broadcom/RaspberryPi
+#     - https://github.com/u-boot/u-boot/blob/master/doc/board/broadcom/raspberrypi.rst
 name: u-boot
 variant: scratch
 shell: /toolchain/bin/bash
@@ -27,12 +29,10 @@ steps:
         sha512: "{{ .uboot_sha512 }}"
     env:
       SUN50I_A64_ARM_TRUSTED_FIRMWARE: sun50i_a64_arm-trusted-firmware
-      RPI_4_A64_ARM_TRUSTED_FIRMWARE: rpi_4_a64_arm-trusted-firmware
       RK3328_ARM_TRUSTED_FIRMWARE: rk3328_arm-trusted-firmware
       RK3399_ARM_TRUSTED_FIRMWARE: rk3399_arm-trusted-firmware
       LIBRETECH_ALL_H3_CC_H5_U_BOOT: libretech_all_h3_cc_h5_u-boot
       ROCK64_RK3328_U_BOOT: rock64_rk3328_u-boot
-      RPI_ARM64_U_BOOT: rpi_4_u-boot
       RPI_ARM64_GENERIC_U_BOOT: rpi_generic_u-boot
       BANANAPI_M64_U_BOOT: bananapi_m64_u-boot
       PINE64_U_BOOT: pine64_u-boot
@@ -71,17 +71,6 @@ steps:
         tar -xjf u-boot.tar.bz2 --strip-components=1 -C ${ROCK64_RK3328_U_BOOT}
         cd ${ROCK64_RK3328_U_BOOT}
         make rock64-rk3328_defconfig
-        sed -i "s/CONFIG_TOOLS_LIBCRYPTO=y/# CONFIG_TOOLS_LIBCRYPTO is not set/" .config
-      # rpi_4_arm-trusted-firmware
-      - |
-        mkdir ${RPI_4_A64_ARM_TRUSTED_FIRMWARE}
-        tar -xzf arm-trusted-firmware.tar.gz --strip-components=1 -C ${RPI_4_A64_ARM_TRUSTED_FIRMWARE}
-      # rpi_4
-      - |
-        mkdir ${RPI_ARM64_U_BOOT}
-        tar -xjf u-boot.tar.bz2 --strip-components=1 -C ${RPI_ARM64_U_BOOT}
-        cd ${RPI_ARM64_U_BOOT}
-        make rpi_4_defconfig
         sed -i "s/CONFIG_TOOLS_LIBCRYPTO=y/# CONFIG_TOOLS_LIBCRYPTO is not set/" .config
       # rpi_generic (built with rpi_arm64_defconfig, which "uses the device-tree provided by the firmware")
       - |
@@ -176,19 +165,6 @@ steps:
         export BL31=$(pwd)/${RK3328_ARM_TRUSTED_FIRMWARE}/build/rk3328/release/bl31/bl31.elf
         cd ${ROCK64_RK3328_U_BOOT}
         make -j $(nproc) HOSTLDLIBS_mkimage="-lssl -lcrypto"
-      # rpi_4_arm-trusted-firmware
-      - |
-        cd ${RPI_4_A64_ARM_TRUSTED_FIRMWARE}
-        make realclean
-        # https://salsa.debian.org/debian/arm-trusted-firmware/-/commit/6424a59e08585af7f8a56f1e16ecc6a6b9e4ad7a
-        # https://salsa.debian.org/debian/arm-trusted-firmware/-/commit/6ed8f61df3b07bb22a68a0fc189ec3b3f7b00dbd
-        # https://developer.trustedfirmware.org/T996
-        TF_LDFLAGS=--no-warn-rwx-segments CFLAGS=--param=min-pagesize=0 make -j $(nproc) PLAT=rpi4 DEBUG=0 bl31
-      # rpi_4
-      - |
-        cd ${RPI_ARM64_U_BOOT}
-        export BL31=$(pwd)/${RPI_4_A64_ARM_TRUSTED_FIRMWARE}/build/rpi4/release/bl31.bin
-        make -j $(nproc) HOSTLDLIBS_mkimage="-lssl -lcrypto"
       # rpi_generic
       - |
         cd ${RPI_ARM64_GENERIC_U_BOOT}
@@ -245,11 +221,6 @@ steps:
       - |
         mkdir -p /rootfs/rock64
         cp -v ${ROCK64_RK3328_U_BOOT}/u-boot-rockchip.bin /rootfs/rock64
-      # rpi_4
-      - |
-        mkdir -p /rootfs/rpi_4
-        cp -v ${RPI_ARM64_U_BOOT}/u-boot.bin /rootfs/rpi_4
-        cp $(pwd)/${RPI_4_A64_ARM_TRUSTED_FIRMWARE}/build/rpi4/release/bl31.bin /rootfs/rpi_4
       # rpi_generic
       - |
         mkdir -p /rootfs/rpi_generic


### PR DESCRIPTION
Use generic Raspberry Pi config instead of board specific ones. This should in theory allow us to support boards listed [here](https://github.com/u-boot/u-boot/blob/master/doc/board/broadcom/raspberrypi.rst)

Related conversation here: https://github.com/siderolabs/talos/issues/6273

Signed-off-by: Noel Georgi <git@frezbo.dev>