### PR TITLE
chore: bump go to 1.19.2

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.2.0-1-gccc64f9
+  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.2.0-2-gdcbd748
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/pkgs


### PR DESCRIPTION
Bump Go to [1.19.2](https://github.com/siderolabs/tools/pull/237)

Signed-off-by: Noel Georgi <git@frezbo.dev>