### PR TITLE
feat: revert kernel to 5.15.72, add UEFI no randomize patch

### DIFF
--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 5.15.68 Kernel Configuration
+# Linux/x86 5.15.72 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.68 Kernel Configuration
+# Linux/arm64 5.15.72 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/prepare/patches/uefi-no-randomize.patch
+++ b/kernel/prepare/patches/uefi-no-randomize.patch
@@ -1,0 +1,44 @@
+Randstruct by default randomizes structures that consist entirely of
+function pointers, even if they are not explicitly labeled for
+randomization. efi_rng_protocol contains an anonymous structure that is
+affected by this implicit selection process. Randomization of this
+structure causes a data layout inconsistency between the kernel and the
+EFI. In this scenario the Arm64 boot process fails with the following
+output:
+    EFI stub: Booting Linux Kernel...
+    EFI stub: ERROR: efi_get_random_bytes() failed (0x8000000000000002)
+    EFI stub: Using DTB from configuration table
+    EFI stub: Loaded initrd from LINUX_EFI_INITRD_MEDIA_GUID device path
+    Synchronous Exception at 0x0000000081310C90
+    Synchronous Exception at 0x0000000081310C90
+
+efi_get_random_bytes() fails in handle_kernel_image (arm64-stub.c)
+because it uses an incorrect structure layout for efi_call_proto. Add
+the __no_randomize_layout annotation to the anonymous structure within
+efi_rng_protocol to prevent its randomization and resolve this issue.
+
+This patch was tested for the Arm64 architecture using QEMU. In
+addition to the current next branch of this subsystem, also minor
+versions 4.16 to 5.1, 5.5 and 5.6 were tested successfully with a
+(backported) version of this patch.
+
+Signed-off-by: Daniel Marth <daniel.marth@inso.tuwien.ac.at>
+---
+ drivers/firmware/efi/libstub/random.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/firmware/efi/libstub/random.c b/drivers/firmware/efi/libstub/random.c
+index 24aa37535372..54fa980cf1af 100644
+--- a/drivers/firmware/efi/libstub/random.c
++++ b/drivers/firmware/efi/libstub/random.c
+@@ -18,7 +18,7 @@ union efi_rng_protocol {
+ 		efi_status_t (__efiapi *get_rng)(efi_rng_protocol_t *,
+ 						 efi_guid_t *, unsigned long,
+ 						 u8 *out);
+-	};
++	} __no_randomize_layout;
+ 	struct {
+ 		u32 get_info;
+ 		u32 get_rng;
+--
+2.37.2

--- a/kernel/prepare/pkg.yaml
+++ b/kernel/prepare/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - image: '{{ .TOOLS_IMAGE }}'
 steps:
   - sources:
-      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.68.tar.xz
+      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.72.tar.xz
         destination: linux.tar.xz
-        sha256: 17bbb3cb5c9ba18583b6679cc28f828aec49c72abbfc6fbde310b0cb17218b7e
-        sha512: fa62e3061a84c7fe79eb69e7c4fd4bf77aebb11ace53fe2bc5a63629a99115d9c406992166ae84526d8854af57cd9cfd173191877ea6639a5fc3c2a60ab22931
+        sha256: 6090323b5b471ae9d3bbc0058966113609f5bbd22fa19a76df32a8abc52f07ab
+        sha512: c6288f664cdc02711382592493c84152f2139b8aa0cdee7d448c7aa75363028a1b7ade15414e7d9d42501f754a6d8eaeeb2dc663ae3b3cc95e9d0882d5aa8d1e
     env:
       ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
     prepare:
@@ -44,6 +44,7 @@ steps:
         cd /toolchain && git clone https://github.com/a13xp0p0v/kconfig-hardened-check.git
       - |
         patch -p1 < /pkg/patches/hardening.kconfig.patch
+        patch -p1 < /pkg/patches/uefi-no-randomize.patch
     install:
       - |
         mkdir -p /src


### PR DESCRIPTION
Use patch from https://lore.kernel.org/all/CAMj1kXH7462XEBis6wL-AOXfDBv-1iKKAn4fOPaKRve1fHkDzQ@mail.gmail.com/T/

This reverts commit 08408bb8f7f9d68234d7875c3fb9d2ea0876ab33.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>