### PR TITLE
fix: drbd package name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ TARGETS = \
 	containerd \
 	cryptsetup \
 	dosfstools \
-	drbd \
+	drbd-pkg \
 	eudev \
 	fhs \
 	flannel-cni \

--- a/drbd/pkg.yaml
+++ b/drbd/pkg.yaml
@@ -1,4 +1,4 @@
-name: drbd
+name: drbd-pkg
 variant: scratch
 shell: /toolchain/bin/bash
 dependencies:


### PR DESCRIPTION
Add the `-pkg` suffix to the drbd pkg.

Signed-off-by: Noel Georgi <git@frezbo.dev>