### PR TITLE
backport: feat: update Linux to 5.15.83

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -68,9 +68,9 @@ vars:
   ipxe_sha512: 2ab64a3f61ef65f7f202751f2c2bb3cf4c335ff4ce9336b5317f4d19e6e8367c1da3703e18f65307fecbf602b5351a39de5b231f6a414c657458f49234da8160
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 5.15.82
-  linux_sha256: fceef6bb79bac494663ccde34453521fc616cd94272fd30564752b3742381b65
-  linux_sha512: b0deb17077d9254e9a6eef853cdbcb7cbdde74cafef214d25961929d02a42fd61d306e3358b17a145999a0df3565c985de6149bd078330c63508ce8ce6fb4938
+  linux_version: 5.15.83
+  linux_sha256: 40590843c04c85789105157f69efbd71a4efe87ae2568e40d1b7258c3f747ff3
+  linux_sha512: 61b12dcdecc96b4fff3cb2596a3da345efb8c6930ffba7ed73930e6c15b1519d8d44a4e86cf281b41c81d993f7f7ba0fe7b6513863fea298039d63cc819ef4e6
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ versioning=loose depName=git://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git
   kmod_version: 30

--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 5.15.82 Kernel Configuration
+# Linux/x86 5.15.83 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 12.2.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.82 Kernel Configuration
+# Linux/arm64 5.15.83 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 12.2.0"
 CONFIG_CC_IS_GCC=y


### PR DESCRIPTION
Updating to the latest LTS release before Talos 1.3.0.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>