### PR TITLE
backport: feat: update Go 1.19.4, Linux 5.15.83, containerd 1.6.12

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.2.0-2-gdcbd748
+  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.2.0-3-g81b11c8
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/pkgs

--- a/containerd/pkg.yaml
+++ b/containerd/pkg.yaml
@@ -7,10 +7,10 @@ dependencies:
 steps:
   - sources:
         # sync with version and revision in build
-      - url: https://github.com/containerd/containerd/archive/refs/tags/v1.6.8.tar.gz
+      - url: https://github.com/containerd/containerd/archive/refs/tags/v1.6.12.tar.gz
         destination: containerd.tar.gz
-        sha256: f5f938513c28377f64f85e84f2750d39f26b01262f3a062b7e8ce35b560ca407
-        sha512: c204c028cdfd76537d1da01c66526fc85b29b02d2412569bb9b265375603614b037356c61846025a72281398f0f46df326a5ea3df97f57901cce85f2f728f0ba
+        sha256: b86e5c42f58b8348422c972513ff49783c0d505ed84e498d0d0245c5992e4320
+        sha512: adec6b28bfeea591af8204341dbdf1477f878be28c318745cacdf1b8de2831e3b4d832ad2026fbd9800d6452b5eb186bd94fe78d4dfed163b1cb32e9a92f38fa
     prepare:
       - |
         tar -xzf containerd.tar.gz --strip-components=1
@@ -22,7 +22,7 @@ steps:
         export CGO_ENABLED=1
         export PATH=${PATH}:${TOOLCHAIN}/go/bin
         export BUILDTAGS='seccomp no_aufs no_btrfs no_devmapper no_zfs'
-        make bin/containerd bin/containerd-shim bin/containerd-shim-runc-v2 VERSION=v1.6.8 REVISION=9cd3357b7fd7218e4aec3eae239db1f68a5a6ec6
+        make bin/containerd bin/containerd-shim bin/containerd-shim-runc-v2 VERSION=v1.6.8 REVISION=a05d175400b1145e5e6a735a6710579d181e7fb0
     install:
       - |
         mkdir -p /rootfs/bin

--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 5.15.79 Kernel Configuration
+# Linux/x86 5.15.83 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y
@@ -1025,6 +1025,7 @@ CONFIG_INET_ESP=y
 # CONFIG_INET_ESP_OFFLOAD is not set
 # CONFIG_INET_ESPINTCP is not set
 CONFIG_INET_IPCOMP=y
+CONFIG_INET_TABLE_PERTURB_ORDER=16
 CONFIG_INET_XFRM_TUNNEL=y
 CONFIG_INET_TUNNEL=y
 # CONFIG_INET_DIAG is not set

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.79 Kernel Configuration
+# Linux/arm64 5.15.83 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y
@@ -1083,6 +1083,7 @@ CONFIG_INET_ESP=y
 # CONFIG_INET_ESP_OFFLOAD is not set
 # CONFIG_INET_ESPINTCP is not set
 CONFIG_INET_IPCOMP=y
+CONFIG_INET_TABLE_PERTURB_ORDER=16
 CONFIG_INET_XFRM_TUNNEL=y
 CONFIG_INET_TUNNEL=y
 # CONFIG_INET_DIAG is not set

--- a/kernel/prepare/pkg.yaml
+++ b/kernel/prepare/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - image: '{{ .TOOLS_IMAGE }}'
 steps:
   - sources:
-      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.79.tar.xz
+      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.83.tar.xz
         destination: linux.tar.xz
-        sha256: cba39031dbc0eed0785b8afdc8c58cf23df83e47001b2354fa44486ae699c154
-        sha512: 5583f5fda70b2abe42212b254fe069f645845a0d664a806435acb898f87470ed25f6591810a406840a5a85479061aea6ed991cdfed29ca540b567d025e5d1326
+        sha256: 40590843c04c85789105157f69efbd71a4efe87ae2568e40d1b7258c3f747ff3
+        sha512: 61b12dcdecc96b4fff3cb2596a3da345efb8c6930ffba7ed73930e6c15b1519d8d44a4e86cf281b41c81d993f7f7ba0fe7b6513863fea298039d63cc819ef4e6
     env:
       ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
     prepare:


### PR DESCRIPTION
Bring release-1.2 to match release-1.3 for critical/security fixes.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>