### PR TITLE
feat: mellanox oped

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ TARGETS = \
 
 # Temporarily disabled until DRBD releases a version compatible with Linux 6.1
 # drbd-pkg \
+# mellanox-ofed-pkg \
 
 NONFREE_TARGETS = nonfree-kmod-nvidia
 

--- a/Pkgfile
+++ b/Pkgfile
@@ -122,6 +122,10 @@ vars:
   lvm2_sha256: 9f683e2980d95c0dcebbd25c7c177032c5615d7267bfc885eabfce59280f4769
   lvm2_sha512: 58043bdcad882065f15d772401d29fc7fb2d0a6b6b75063915dc38bb11cd847517dd18ae7e2acb3935e6c32ef620a275c2b2b9c307434f7457ea3203b87254c1
 
+  mellanox_ofed_version: 5.8-1.1.2.1
+  mellanox_ofed_sha256: 0ac9b9f400f8d6ce7cb99bb990ede7084885f88336a5fae6048dbcb3d3877087
+  mellanox_ofed_sha512: c9f98ec0fda7a6eb20e85a76e01fec2b53c65a15af7614e613d104f849f117ecb2230b9fece0dff198eeef36f1a40debda1493ac4913c8cb21f484cf84eaa258
+
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.musl-libc.org/musl
   musl_version: 1.2.3
   musl_sha256: 7d5b0b6062521e4627e099e4c9dc8248d32a30285e959b7eecaa780cf8cfd4a4

--- a/mellanox-ofed/pkg.yaml
+++ b/mellanox-ofed/pkg.yaml
@@ -1,0 +1,55 @@
+name: mellanox-ofed-pkg
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: kernel-build
+steps:
+  - sources:
+      - url: https://www.mellanox.com/downloads/ofed/MLNX_OFED-{{ .mellanox_ofed_version }}/MLNX_OFED_SRC-debian-{{ .mellanox_ofed_version }}.tgz
+        destination: mellanox_ofed.tgz
+        sha256: "{{ .mellanox_ofed_sha256 }}"
+        sha512: "{{ .mellanox_ofed_sha512 }}"
+    env:
+      ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
+    prepare:
+      - |
+        tar -xzf mellanox_ofed.tgz --strip-components=1
+
+        cd SOURCES
+        tar xf mlnx-ofed-kernel_5.8.orig.tar.gz
+    build:
+      - |
+        cd SOURCES/mlnx-ofed-kernel-5.8
+
+        ./configure --with-core-mod \
+          --with-user_mad-mod \
+          --with-user_access-mod \
+          --with-addr_trans-mod \
+          --with-mlx4-mod \
+          --with-mlx4_en-mod \
+          --with-mlx5-mod \
+          --with-ipoib-mod \
+          --with-srp-mod \
+          --with-rds-mod \
+          --with-iser-mod \
+          --kernel-sources=/src \
+          -j $(nproc)
+
+        make kernel -j $(nproc)
+    install:
+      - |
+        cd SOURCES/mlnx-ofed-kernel-5.8
+
+        mkdir -p /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
+        cp /src/modules.order /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
+        cp /src/modules.builtin /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
+        cp /src/modules.builtin.modinfo /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
+
+        make install_modules DEPMOD=/toolchain/bin/depmod INSTALL_MOD_PATH=/rootfs INSTALL_MOD_DIR=extras
+    test:
+      - |
+        # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping
+        find /rootfs/lib/modules -name '*.ko' -exec grep -FL '~Module signature appended~' {} \+
+finalize:
+  - from: /rootfs
+    to: /


### PR DESCRIPTION
Mellanox OFED drivers, currently this only builds with kernel 5.15
series, so keep it disabled until there's a new version that builds with
kernel 6.1

Signed-off-by: Noel Georgi <git@frezbo.dev>