### PR TITLE
chore: use default symlinks to `/bin` in `base`

### DIFF
--- a/base/pkg.yaml
+++ b/base/pkg.yaml
@@ -12,9 +12,8 @@ steps:
         cp -R /toolchain/lib/libz* /lib
 
         mkdir /bin
-        ln -sv /toolchain/bin/bash /bin/bash
+        find /toolchain/bin -type f -executable -printf "%f\n" | xargs -I {} ln -s /toolchain/bin/{} /bin/{}
         ln -sv /toolchain/bin/bash /bin/sh
-        ln -sv /toolchain/bin/pwd /bin/pwd
 
         adjust.sh
 finalize:

--- a/ipxe/pkg.yaml
+++ b/ipxe/pkg.yaml
@@ -15,7 +15,6 @@ steps:
       IPXE_VERSION: 1.21.1+git+{{ substr 0 7 .ipxe_ref }}+sidero
     prepare:
       - |
-        ln -s /toolchain/bin/echo /bin/echo
         tar -xzf ipxe.tar.gz --strip-components=1
 
         patch -p1 < /pkg/patches/https.patch


### PR DESCRIPTION
Use default symlinks from `/toolchain/bin` to `/bin` in `base`.

Signed-off-by: Noel Georgi <git@frezbo.dev>