### PR TITLE
backport: feat: Linux 5.15.86, containerd 1.6.15

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -11,10 +11,10 @@ vars:
   cni_sha512: 03da31caee5f9595abf65d4a551984b995bc18c5e97409549f08997c5a6a2b41a8950144f8a5b4f810cb401ddbe312232d2be76ec977acf8108eb490786b1817
 
   # renovate: datasource=github-tags depName=containerd/containerd
-  containerd_version: v1.6.14
-  containerd_ref: 9ba4b250366a5ddde94bb7c9d1def331423aa323
-  containerd_sha256: 158dd5aa5c6c4aa1f118baee3e30aaaf200b274b9eecfeb75297679a1609bfb7
-  containerd_sha512: d29e2fb4a43f12d7e196f95b59b2c55793a1848177fb64b8bd9a4fd299fe54680a26f8a809b1d63f653ed9f0b30c209fc39d46b78ac0914d3253a10e5d3b015b
+  containerd_version: v1.6.15
+  containerd_ref: 5b842e528e99d4d4c1686467debf2bd4b88ecd86
+  containerd_sha256: ee170fa73b258e448f9b6729440d38c77d19cd9bec46e45cd195d4670cd8b004
+  containerd_sha512: 5e0192d7fcffee98b5c355ab2330520dc0c64bc4c5c48111de0f84f0273707857bb6207e98c382498ea1b0448fcf7a05626113e4cffdb5cd8cbd9549346780c8
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/cryptsetup/cryptsetup.git
   cryptsetup_version: 2.5.0
@@ -68,9 +68,9 @@ vars:
   ipxe_sha512: 2ab64a3f61ef65f7f202751f2c2bb3cf4c335ff4ce9336b5317f4d19e6e8367c1da3703e18f65307fecbf602b5351a39de5b231f6a414c657458f49234da8160
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 5.15.85
-  linux_sha256: 2c0bae29fac98e0a9408914a4551b2971365ac0000351cb255d6bd9aa0849808
-  linux_sha512: 8cc19124c82f14e09b5ff8d2e343cd41cdfced74e5c0c501abd258555d9dbaa79e79cb23256a474cd59311ae8626b0457c2117263bd64a206151c09b54f3ff46
+  linux_version: 5.15.86
+  linux_sha256: 80fcd9efa443502de9e2750f6dfb59e8de43a5d87a6d2be09dca748d79b5f2ee
+  linux_sha512: 5acbf5e7ff56484b8a4eda3f7e1662029eb2bc7621082386887ba893bef172da49512f1a6e05c590c32e591c3d8b1a41c6a11fc1befe5196f28e60c9f0a7b22f
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ versioning=loose depName=git://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git
   kmod_version: 30

--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 5.15.85 Kernel Configuration
+# Linux/x86 5.15.86 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 12.2.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.85 Kernel Configuration
+# Linux/arm64 5.15.86 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 12.2.0"
 CONFIG_CC_IS_GCC=y
@@ -6446,7 +6446,6 @@ CONFIG_EXTCON=y
 # CONFIG_EXTCON_RT8973A is not set
 # CONFIG_EXTCON_SM5502 is not set
 CONFIG_EXTCON_USB_GPIO=y
-# CONFIG_EXTCON_USBC_TUSB320 is not set
 CONFIG_MEMORY=y
 # CONFIG_ARM_PL172_MPMC is not set
 CONFIG_BRCMSTB_DPFE=y


### PR DESCRIPTION
See https://github.com/containerd/containerd/releases/tag/v1.6.15

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>