### PR TITLE
chore: disable provenance in buildx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ PLATFORM ?= linux/amd64,linux/arm64
 PROGRESS ?= auto
 PUSH ?= false
 COMMON_ARGS := --file=Pkgfile
+COMMON_ARGS += --provenance=false
 COMMON_ARGS += --progress=$(PROGRESS)
 COMMON_ARGS += --platform=$(PLATFORM)
 COMMON_ARGS += --build-arg=http_proxy=$(http_proxy)


### PR DESCRIPTION
For some reason the builds fail to push the image to ghcr.io. I can't reproduce that locally pushing to my username at ghcr.io, but this provenance thing is the only thing I can think as a big change in buildkit 0.11.0/buildx 0.10.0, so trying to disable it.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>