### PR TITLE
fix: missing kernel module tree files

### DIFF
--- a/drbd/pkg.yaml
+++ b/drbd/pkg.yaml
@@ -20,9 +20,11 @@ steps:
     install:
       - |
         mkdir -p /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
-        touch /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/modules.order /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/modules.builtin
+        cp /src/modules.order /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
+        cp /src/modules.builtin /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
+        cp /src/modules.builtin.modinfo /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
 
-        make -j $(nproc) -C /src M=$(pwd)/drbd modules_install DESTDIR=/rootfs INSTALL_MOD_PATH=/rootfs CONFIG_MODULE_SIG_ALL=y
+        make -j $(nproc) -C /src M=$(pwd)/drbd modules_install DESTDIR=/rootfs INSTALL_MOD_PATH=/rootfs INSTALL_MOD_DIR=extras CONFIG_MODULE_SIG_ALL=y
     test:
       - |
         # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping

--- a/gasket-driver/pkg.yaml
+++ b/gasket-driver/pkg.yaml
@@ -23,11 +23,11 @@ steps:
     install:
       - |
         mkdir -p /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
+        cp /src/modules.order /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
+        cp /src/modules.builtin /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
+        cp /src/modules.builtin.modinfo /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
 
-        # create these so we don't get warnings when depmod runs
-        touch /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/modules.order /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/modules.builtin
-
-        make -C /src M=$(pwd)/src modules_install INSTALL_MOD_PATH=/rootfs
+        make -C /src M=$(pwd)/src modules_install INSTALL_MOD_PATH=/rootfs INSTALL_MOD_DIR=extras
     test:
       - |
         # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping

--- a/nonfree/kmod-nvidia/pkg.yaml
+++ b/nonfree/kmod-nvidia/pkg.yaml
@@ -37,9 +37,11 @@ steps:
         cd NVIDIA-Linux-*/kernel
 
         mkdir -p /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
-        touch /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/modules.order /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/modules.builtin
+        cp /src/modules.order /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
+        cp /src/modules.builtin /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
+        cp /src/modules.builtin.modinfo /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
 
-        make -j $(nproc) modules_install SYSSRC=/src DEPMOD=/toolchain/bin/depmod INSTALL_MOD_PATH=/rootfs
+        make -j $(nproc) modules_install SYSSRC=/src DEPMOD=/toolchain/bin/depmod INSTALL_MOD_PATH=/rootfs INSTALL_MOD_DIR=extras
 finalize:
   - from: /rootfs
     to: /

--- a/nvidia-open-gpu-kernel-modules/pkg.yaml
+++ b/nvidia-open-gpu-kernel-modules/pkg.yaml
@@ -26,9 +26,11 @@ steps:
     install:
       - |
         mkdir -p /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
-        touch /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/modules.order /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/modules.builtin
+        cp /src/modules.order /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
+        cp /src/modules.builtin /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
+        cp /src/modules.builtin.modinfo /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
 
-        make -j $(nproc) modules_install SYSSRC=/src DEPMOD=/toolchain/bin/depmod INSTALL_MOD_PATH=/rootfs
+        make -j $(nproc) modules_install SYSSRC=/src DEPMOD=/toolchain/bin/depmod INSTALL_MOD_PATH=/rootfs INSTALL_MOD_DIR=extras
     test:
       - |
         # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping


### PR DESCRIPTION
https://github.com/siderolabs/talos/issues/6751 was not a complete fix for https://github.com/siderolabs/talos/issues/6681. This fixed all driver builds to copy over `modules.builtin` and also make sure they are installed in `extras` so that proper module dependency tree is generated by Talos on installing drivers built as extensions.

Signed-off-by: Noel Georgi <git@frezbo.dev>