### PR TITLE
fix: sourcefourge url shasums

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.4.0-alpha.0-17-gcd9687b
+  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.4.0-alpha.0-19-ga8440a9
 
   # renovate: datasource=github-releases depName=containernetworking/plugins
   cni_version: v1.2.0

--- a/liblzma/pkg.yaml
+++ b/liblzma/pkg.yaml
@@ -5,8 +5,7 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      # redirect url of https://tukaani.org/xz/xz-{{ .xz_version }}.tar.xz
-      - url: https://udomain.dl.sourceforge.net/project/lzmautils/xz-{{ .xz_version | replace "v" "" }}.tar.xz
+      - url: https://github.com/tukaani-project/xz/releases/download/{{ .xz_version }}/xz-{{ .xz_version | replace "v" "" }}.tar.xz
         destination: xz.tar.xz
         sha256: "{{ .xz_sha256 }}"
         sha512: "{{ .xz_sha512 }}"


### PR DESCRIPTION
Sourcefource url's are prone to providing different file shasums at times. Fix by using from xz git repo releases.