### PR TITLE
backport: feat: update containerd to 1.6.20

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -11,10 +11,10 @@ vars:
   cni_sha512: fb6fb4f46ac1610b3721f5f3a6ddfb096cbf2e5d5b792306edca5351a3944d2f802170d83e5adec01420395bf64fc8a174ede61ac9b93b5ac6b938a4b48651e6
 
   # renovate: datasource=github-tags depName=containerd/containerd
-  containerd_version: v1.6.19
-  containerd_ref: 1e1ea6e986c6c86565bc33d52e34b81b3e2bc71f
-  containerd_sha256: 7a90dc72f44e230eb5228ebac23b37e91f7d26d175d563099a8e1c0592047a28
-  containerd_sha512: dca78d472dfbc6fc4d9b0b3a0d0a131d3575163c52e4fe18ea2c6147868b8822c54046c0709974e9b90472b882ba3890ada7f0fcbf31549efffba0d91531886c
+  containerd_version: v1.6.20
+  containerd_ref: 2806fc1057397dbaeefbea0e4e17bddfbd388f38
+  containerd_sha256: 819086ccdca44cfc5f108e226c7a9294d8fad3eb32031a621623da80dedbfb11
+  containerd_sha512: dd9708c99d95773a78b0fcd77b388cb8a971d0d65502c8b86cbb3b29c48bac31366ae0603d7710a13c21c33adcd341cdec69dcb3c3a06a2d753c4c59f2549d75
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/cryptsetup/cryptsetup.git
   cryptsetup_version: 2.6.1


### PR DESCRIPTION
See https://github.com/containerd/containerd/releases/tag/v1.6.20

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
(cherry picked from commit fb853ff6b1194cdc1f2412c776347cf4b55c3336)