### PR TITLE
chore: reorder pkgs for better kernel caching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ COMMON_ARGS += --build-arg=SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH)
 empty :=
 space = $(empty) $(empty)
 
+# TARGETS are split into two groups:
+# - non-related to the kernel, in alphabetical order
 TARGETS = \
 	base \
 	ca-certificates \
@@ -37,16 +39,13 @@ TARGETS = \
 	containerd \
 	cryptsetup \
 	dosfstools \
-	drbd-pkg \
 	eudev \
 	fhs \
 	flannel-cni \
-	gasket-driver-pkg \
 	grub \
 	ipmitool \
 	iptables \
 	ipxe \
-	kernel \
 	kmod \
 	libaio \
 	libinih \
@@ -58,7 +57,6 @@ TARGETS = \
 	linux-firmware \
 	lvm2 \
 	musl \
-	nvidia-open-gpu-kernel-modules-pkg \
 	openssl \
 	raspberrypi-firmware \
 	runc \
@@ -67,6 +65,14 @@ TARGETS = \
 	u-boot \
 	util-linux \
 	xfsprogs
+
+# - kernel & dependent packages (out of tree kernel modules)
+#   kernel first, then packages in alphabetical order
+TARGETS += \
+	kernel \
+	drbd-pkg \
+	gasket-driver-pkg \
+	nvidia-open-gpu-kernel-modules-pkg \
 
 # Temporarily disabled until mellanox builds with Linux 6.1
 # mellanox-ofed-pkg \


### PR DESCRIPTION
Reorder the build so that kernel-related packages are closer to the kernel, this way we should lower the probability of the cache purge for the kernel build.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
(cherry picked from commit 41629b03e82bfb77623a812000ef8e98d15d56fa)