### PR TITLE
backport: chore: copy over the kernel signing public key

### DIFF
--- a/kernel/kernel/pkg.yaml
+++ b/kernel/kernel/pkg.yaml
@@ -12,6 +12,8 @@ steps:
 
         mkdir -p /rootfs/boot
         mkdir -p /rootfs/dtb
+        mkdir -p /rootfs/certs
+        cp /src/certs/signing_key.x509 /rootfs/certs/signing_key.x509
         case $ARCH in
             x86_64)
                 mv arch/x86/boot/bzImage /rootfs/boot/vmlinuz


### PR DESCRIPTION
Copy over the kernel signing public key so that it can be used to verify modules are signed by the correct key. The signing key is copied over as otherwise in-order to extract the signing key we either need the uncompressed `vmlinux` (which is super huge to copy over) or need the `System.map` file along with `vmlinuz` and a perl script to extract it. It's just easier to just copy over the `signing_key.x509` file.

Signed-off-by: Noel Georgi <git@frezbo.dev>
(cherry picked from commit 4eae958770573613bc29568d130be7aaa775e530)