### PR TITLE
backport: feat: update Linux to 6.1.24

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -68,9 +68,9 @@ vars:
   ipxe_sha512: b241fd32d9a2100f99334d9d09e2736af0ea724923f66693e574e480a616fed2cd127f6851bea1c80fd35792048700afcb18e42eb3c3d2b35816d3917cbfb0c2
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 6.1.23
-  linux_sha256: 7458372e8750afe37fd1ac3e7ab3c22f2c6018f760f8134055a03f54aba3ebeb
-  linux_sha512: 6b57cff7222e3c193f5b54f8381b18ee3f15544a8c8cd8c5c5eb5504044e2ade93744c0324bd275beecbcc1dc4ec650aed4a563ca575aae764b14c785584f661
+  linux_version: 6.1.24
+  linux_sha256: aae6a7e38e33589011f5a5c0d7e087c8a26e3daf8d434432ee975ead90546504
+  linux_sha512: 8dd946ae969e3a51d82f8c5383cb4af8ec457b5ad2174a09a39f86db9c3d5992b9c394652780ad6f31aa6a2d90a9768bf86fc9d15a63bb6bda1e1a031554d83a
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git
   kmod_version: 30

--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 6.1.23 Kernel Configuration
+# Linux/x86 6.1.24 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 12.2.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.1.23 Kernel Configuration
+# Linux/arm64 6.1.24 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 12.2.0"
 CONFIG_CC_IS_GCC=y


### PR DESCRIPTION
Latest LTS in 6.1.x.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
(cherry picked from commit 988f1ecf95536fb259cbd79e044a556728bc7332)