### PR TITLE
chore: selectively build modules

### DIFF
--- a/kernel/build/pkg.yaml
+++ b/kernel/build/pkg.yaml
@@ -20,7 +20,11 @@ steps:
         cd /src
 
         make -j $(nproc)
-        make -j $(nproc) modules
+        {{ if eq .ARCH "aarch64"}}
+        make -j $(nproc) M=drivers/net/ethernet/mellanox
+        {{ else }}
+        make -j $(nproc) M=drivers/virtio M=drivers/net/ethernet/mellanox
+        {{ end }}
 
         if [[ "${ARCH}" == "arm64" ]]; then
           echo "Compiling device-tree blobs"


### PR DESCRIPTION
This change allows the Talos kernel to be shipped with modules that are currently being built as modules (mellanox and virtio). Any extra module can still be enabled in kernel config but won't be shipped by default. They can be built as extensions and enabled separately.