### PR TITLE
chore: bump kernel to 6.1.28

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -68,9 +68,9 @@ vars:
   ipxe_sha512: 8f2463be62d6ce3b87dffe0b95b31db7245d43a6fdd476c19441ce50026c77d54b43dc264ea9c9df7086cdd984e6237cd11766b7815bc71b275ded2e0136cb1d
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 6.1.27
-  linux_sha256: c2b74b96dd3d0cc9f300914ef7c4eef76d5fac9de6047961f49e69447ce9f905
-  linux_sha512: 657c241c8e4d62dabf7f1789c342352f757655129b8b21d92d3a90859d24f5f05f33aa39491851f690f7d9b0ba9234c47907ae05e1cb32a8d00fcf11ff71c61b
+  linux_version: 6.1.28
+  linux_sha256: 7a094c1428b20fef0b5429e4effcc6ed962a674ac6f04e606d63be1ddcc3a6f0
+  linux_sha512: 7215e62df10847e8bce432880e0756e8a5f56eb8b8abb54f9e1eb8871ce7bd56d765be0f9a40a8dae4d135b2f9a0dab7f6b3d2691d73b0c47f05811194dee8bd
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git
   kmod_version: 30

--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 6.1.27 Kernel Configuration
+# Linux/x86 6.1.28 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 12.2.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.1.27 Kernel Configuration
+# Linux/arm64 6.1.28 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 12.2.0"
 CONFIG_CC_IS_GCC=y


### PR DESCRIPTION
Bump kernel to 6.1.28