### PR TITLE
fix: copy missing `modules.*` files

### DIFF
--- a/usb-modem-drivers/files/modules.txt
+++ b/usb-modem-drivers/files/modules.txt
@@ -1,3 +1,6 @@
+modules.order
+modules.builtin
+modules.builtin.modinfo
 kernel/drivers/net/usb/dm9601.ko
 kernel/drivers/net/usb/rndis_host.ko
 kernel/drivers/net/usb/smsc75xx.ko


### PR DESCRIPTION
Copy missing `modules.order`, `modules.builtin` and `modules.builtin.modinfo` files so tools can read them.