### PR TITLE
backport: feat: update Linux to 6.1.41

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -68,9 +68,9 @@ vars:
   ipxe_sha512: b241fd32d9a2100f99334d9d09e2736af0ea724923f66693e574e480a616fed2cd127f6851bea1c80fd35792048700afcb18e42eb3c3d2b35816d3917cbfb0c2
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 6.1.35
-  linux_sha256: be368143bc5d0dc73dd3e8c6191630c1620520379baf6f47c16116b2c0bc26ac
-  linux_sha512: 7945932912c955825f66ec72adf1ad9ff685a966e82d8a91e22919e8794b3d560c96aa0bba5376cf4b99690b4419e86ae2a7d5e52e056b858fde57a277417b33
+  linux_version: 6.1.41
+  linux_sha256: 312809a78eea052a08a6580f47b2ed8dd28e5633461d6731febaf3cb1e570bb7
+  linux_sha512: 82101034257f746e1b6717d374a7960c1a83f93e8c2912e159c6eda6ea7605ff3c8505d37cc55ee0aadaddc964475c7ece4c26ed60407877d6eeaa7938de7c91
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git
   kmod_version: 30

--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 6.1.35 Kernel Configuration
+# Linux/x86 6.1.41 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 12.2.0"
 CONFIG_CC_IS_GCC=y
@@ -1011,6 +1011,7 @@ CONFIG_SECRETMEM=y
 CONFIG_LRU_GEN=y
 # CONFIG_LRU_GEN_ENABLED is not set
 # CONFIG_LRU_GEN_STATS is not set
+CONFIG_LOCK_MM_AND_FIND_VMA=y
 
 #
 # Data Access Monitoring
@@ -5059,7 +5060,7 @@ CONFIG_CIFS_DFS_UPCALL=y
 # CONFIG_CIFS_SMB_DIRECT is not set
 # CONFIG_CIFS_ROOT is not set
 # CONFIG_SMB_SERVER is not set
-CONFIG_SMBFS_COMMON=y
+CONFIG_SMBFS=y
 # CONFIG_CODA_FS is not set
 # CONFIG_AFS_FS is not set
 CONFIG_NLS=y

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.1.35 Kernel Configuration
+# Linux/arm64 6.1.41 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 12.2.0"
 CONFIG_CC_IS_GCC=y
@@ -1057,6 +1057,7 @@ CONFIG_ARCH_HAS_PTE_SPECIAL=y
 CONFIG_LRU_GEN=y
 # CONFIG_LRU_GEN_ENABLED is not set
 # CONFIG_LRU_GEN_STATS is not set
+CONFIG_LOCK_MM_AND_FIND_VMA=y
 
 #
 # Data Access Monitoring
@@ -7635,7 +7636,7 @@ CONFIG_CIFS_DFS_UPCALL=y
 # CONFIG_CIFS_SMB_DIRECT is not set
 # CONFIG_CIFS_ROOT is not set
 # CONFIG_SMB_SERVER is not set
-CONFIG_SMBFS_COMMON=y
+CONFIG_SMBFS=y
 # CONFIG_CODA_FS is not set
 # CONFIG_AFS_FS is not set
 CONFIG_NLS=y


### PR DESCRIPTION
This release contains a workaround for
[Zenbleed](https://lock.cmpxchg8b.com/zenbleed.html).