### PR TITLE
chore: enable pushing of non-free packages

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -121,6 +121,7 @@ steps:
     commands:
       - docker login ghcr.io --username "$${GHCR_USERNAME}" --password "$${GHCR_PASSWORD}"
       - make PUSH=true
+      - make nonfree PUSH=true
     when:
       event:
         exclude:


### PR DESCRIPTION
At the moment it is kmod-nvidia.

Signed-off-by: Andrey Smirnov <andrey.smirnov@siderolabs.com>
(cherry picked from commit 30cd5846bd7a9cbf5e79c23b9e42a65a213276e2)