### PR TITLE
backport: chore: update Go to 1.20.7

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.4.0-4-g78b2dc6
+  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.4.0-5-g6889ef6
 
   # renovate: datasource=github-releases depName=containernetworking/plugins
   cni_version: v1.2.0


### PR DESCRIPTION
This is backport for Talos 1.4.8.