### PR TITLE
fix: nonfree kmod pkg name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ TARGETS = \
 #   kernel first, then packages in alphabetical order
 TARGETS += \
 	kernel \
+	btrfs-pkg \
 	drbd-pkg \
 	gasket-driver-pkg \
 	nvidia-open-gpu-kernel-modules-pkg \
@@ -81,7 +82,7 @@ TARGETS += \
 # Temporarily disabled until mellanox builds with Linux 6.1
 # mellanox-ofed-pkg \
 
-NONFREE_TARGETS = nonfree-kmod-nvidia
+NONFREE_TARGETS = nonfree-kmod-nvidia-pkg
 
 all: $(TARGETS) ## Builds all known pkgs.
 

--- a/nonfree/kmod-nvidia/pkg.yaml
+++ b/nonfree/kmod-nvidia/pkg.yaml
@@ -1,4 +1,4 @@
-name: nonfree-kmod-nvidia
+name: nonfree-kmod-nvidia-pkg
 variant: scratch
 shell: /toolchain/bin/bash
 dependencies:


### PR DESCRIPTION
Add `-pkg` suffix to nonfree kmod nvidia.