### PR TITLE
fix: nonfree kmod pkg name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ TARGETS += \
 # Temporarily disabled until mellanox builds with Linux 6.1
 # mellanox-ofed-pkg \
 
-NONFREE_TARGETS = nonfree-kmod-nvidia
+NONFREE_TARGETS = nonfree-kmod-nvidia-pkg
 
 all: $(TARGETS) ## Builds all known pkgs.
 

--- a/nonfree/kmod-nvidia/pkg.yaml
+++ b/nonfree/kmod-nvidia/pkg.yaml
@@ -1,4 +1,4 @@
-name: nonfree-kmod-nvidia
+name: nonfree-kmod-nvidia-pkg
 variant: scratch
 shell: /toolchain/bin/bash
 dependencies:


### PR DESCRIPTION
Add `-pkg` suffix to nonfree kmod nvidia.

Signed-off-by: Noel Georgi <git@frezbo.dev>
(cherry picked from commit c4eac999135f8669d8f3f2d330b6208ae804cc86)