### PR TITLE
feat: add applesmc package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ TARGETS = \
 #   kernel first, then packages in alphabetical order
 TARGETS += \
 	kernel \
+	applesmc-pkg \
 	btrfs-pkg \
 	drbd-pkg \
 	gasket-driver-pkg \

--- a/Pkgfile
+++ b/Pkgfile
@@ -192,5 +192,11 @@ vars:
   zfs_version: 2.1.12
   zfs_sha256: 64daa26aed3e12c931f6f4413d7527c4ebdb8da35416b356152b5f9fdd4c6e6d
   zfs_sha512: f48493a21883e441cda705fb085353bed033f1620a1d0f93069c345c76cf2c0759a2e6f7a80c47c9398e9878abfe1d90d931fe5ceaf2588770a71491a434631e
+
+  # DO NOT bump until we are on kernel version 6.2 or newer.
+  # renovate: datasource=git-refs versioning=git depName=https://github.com/t2linux/linux-t2-patches.git
+  linux_t2_patches_ref: 71eb8c9335cafc6b1fd2dbd5415ae24ceb30e32c
+  linux_t2_patches_sha256: 2a5317ae622b70c4a96e494e3a64a6033b07fe3a7cc86ba5812addf7585b5f2d
+  linux_t2_patches_sha512: dcd3d3d23de7afa3a996cfbc80951ca3855e82d59bf778eb4acfde0a232484a77fd7f76a869fa454c4e2a8f2d7c7116936a51c3c24c19c6b621eb545e62fc6dc
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/pkgs

--- a/applesmc/pkg.yaml
+++ b/applesmc/pkg.yaml
@@ -1,0 +1,47 @@
+name: applesmc-pkg
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: kernel-build
+steps:
+# {{ if eq .ARCH "x86_64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr restricting build to amd64 only
+  - sources:
+      - url: https://github.com/t2linux/linux-t2-patches/archive/{{ .linux_t2_patches_ref }}.tar.gz
+        destination: patches.tar.gz
+        sha256: "{{ .linux_t2_patches_sha256 }}"
+        sha512: "{{ .linux_t2_patches_sha512 }}"
+    env:
+      ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
+    prepare:
+      - |
+        mkdir -p /pkg/patches
+        tar xf patches.tar.gz --strip-components=1 -C /pkg/patches
+      - |
+        cd /src
+        while IFS= read -r file; do
+          echo "==> Adding $file"
+          patch -p1 < "$file"
+        done < <(find "/pkg/patches/" -type f -name "3***.patch" | sort)
+    build:
+      - |
+        make -j $(nproc) -C /src M=drivers/hwmon modules CONFIG_SENSORS_APPLESMC=m
+    install:
+      - |
+        mkdir -p /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
+        cp /src/modules.order /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
+        cp /src/modules.builtin /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
+        cp /src/modules.builtin.modinfo /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
+
+        make -j $(nproc) -C /src M=drivers/hwmon modules_install INSTALL_MOD_PATH=/rootfs INSTALL_MOD_DIR=extras INSTALL_MOD_STRIP=1 CONFIG_MODULE_SIG_ALL=y
+    test:
+      - |
+        # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping
+        find /rootfs/lib/modules -name '*.ko' -exec grep -FL '~Module signature appended~' {} \+
+# {{ else }}
+  - install:
+      - |
+        mkdir -p /rootfs
+# {{ end }}
+finalize:
+  - from: /rootfs
+    to: /


### PR DESCRIPTION
This adds the `applesmc` pkg to use in extensions.

Because of the nature of applesmc on T2 mac's, they are using patches currently.

Currently this targets the 6.1 (kernel) branch of https://github.com/t2linux/linux-t2-patches. I put the renovate comment in and a note to not bump it unless we start building with 6.2+, which then we would switch the reference.

I'm willing to keep the `applesmc` extension up to date as I depend on it.

Extension: https://github.com/siderolabs/extensions/pull/207