### PR TITLE
chore: fix cacert perms

### DIFF
--- a/ca-certificates/pkg.yaml
+++ b/ca-certificates/pkg.yaml
@@ -1,13 +1,14 @@
 name: ca-certificates
 steps:
   - sources:
-      - url: https://curl.se/ca/cacert-2023-01-10.pem
+      - url: https://curl.se/ca/cacert-2023-08-22.pem
         destination: cacert.pem
-        sha256: fb1ecd641d0a02c01bc9036d513cb658bbda62a75e246bedbc01764560a639f0
-        sha512: 08cd35277bf2260cb3232d7a7ca3cce6b2bd58af9221922d2c6e9838a19c2f96d1ca6d77f3cc2a3ab611692f9fec939e9b21f67442282e867a487b0203ee0279
+        sha256: 23c2469e2a568362a62eecf1b49ed90a15621e6fa30e29947ded3436422de9b9
+        sha512: 26a6696b4b17a8d95a6baeaf0643e21789eae033a680c18ff7083d3dea70b908e12c6afeb39aee0025c4f65428d2c2944576893936818426c5030d7e150ef1c2
     install:
       - |
         mkdir -p /rootfs/etc/ssl/certs
+        chmod 644 cacert.pem
         mv cacert.pem /rootfs/etc/ssl/certs/ca-certificates
 finalize:
   - from: /rootfs


### PR DESCRIPTION
Make the cacert file world readable, so kresfied projects running an non-root user can access CA.

Part of fixing: https://github.com/siderolabs/talos-backup/issues/7

Before:

```bash
❯ ls -l _out/etc/ssl/certs/
.rw------- 221k frezbo  2 Jun  2019 ca-certificates
```

After:

```bash
❯ ls -l _out/etc/ssl/certs/
.rw-r--r-- 221k frezbo  2 Jun  2019 ca-certificates
```