### PR TITLE
chore: rename kconfig-hardened-check

### DIFF
--- a/kernel/build/pkg.yaml
+++ b/kernel/build/pkg.yaml
@@ -15,7 +15,7 @@ steps:
     build:
       - |
         cd /src
-        python3 /toolchain/kconfig-hardened-check/bin/kconfig-hardened-check -c .config -m json | python3 /pkg/scripts/filter-hardened-check.py
+        python3 /toolchain/kernel-hardening-checker/bin/kernel-hardening-checker -c .config -m json | python3 /pkg/scripts/filter-hardened-check.py
       - |
         cd /src
 

--- a/kernel/prepare/pkg.yaml
+++ b/kernel/prepare/pkg.yaml
@@ -41,7 +41,7 @@ steps:
 
         make mrproper
       - |
-        cd /toolchain && git clone https://github.com/a13xp0p0v/kconfig-hardened-check.git
+        cd /toolchain && git clone https://github.com/a13xp0p0v/kernel-hardening-checker.git
     install:
       - |
         mkdir -p /src


### PR DESCRIPTION
`kconfig-hardened-check` -> `kernel-hardening-checker`

Upstream renamed: https://github.com/a13xp0p0v/kernel-hardening-checker/pull/85

Signed-off-by: Noel Georgi <git@frezbo.dev>
(cherry picked from commit 4504f83f668776161af56853c3faec61edc4cdb6)