### PR TITLE
feat: update Linux to 6.1.61

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -68,9 +68,9 @@ vars:
   ipxe_sha512: 6ae707f53a657b7c7974cf4b3f9cba576147c2ec54d780484b18f053bdaa70cede45d01e667733b4a23c8661aa536f56da257fddac0212ef9a0f5ec52c54e0fd
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 6.1.58
-  linux_sha256: ce987ed3d2f640b3a2a62a0a8573d538a36dfd3cc31e2d7a239ce5a16c1c21ad
-  linux_sha512: bbf1e0a41d10ec23485bf99d239dd08f2914660fc8ae6858ca01cea8689d9a3ccbb5e9dfae6d5b8283485055f9b1aaf35f98ff3ef80599a654885b317527121a
+  linux_version: 6.1.61
+  linux_sha256: ad2c9d12fc36e2dde4796a3eec8f4ddca2e278098f4e555b6e6f5f03ef6964ce
+  linux_sha512: cc4bc51abca165701ad0a5a13e2b4b0fe7f55a3ea1d0d709b714d490b1952058ed1ed3934554827b6edbaedf9609bc0e1aaa0bb238672e040ed47c34d3723b97
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git
   kmod_version: 30

--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 6.1.58 Kernel Configuration
+# Linux/x86 6.1.61 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 12.3.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.1.58 Kernel Configuration
+# Linux/arm64 6.1.61 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 12.3.0"
 CONFIG_CC_IS_GCC=y


### PR DESCRIPTION
This is backport for Talos 1.5.x.