### PR TITLE
feat: update Go to 1.21.5

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,12 +3,12 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.6.0
+  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.7.0-alpha.0
 
   # renovate: datasource=github-releases depName=containernetworking/plugins
-  cni_version: v1.3.0
-  cni_sha256: f9871b9f6ccb51d2b264532e96521e44f926928f91434b56ce135c95becf2901
-  cni_sha512: 87e186b3cd64f66280f5b2293dcdd1fc22cb8f51a248124fb622adc48a893348419ba4c29c4769dede4d9e60f2e9fea5d4198f10badb4ecd20a1551e0b344e10
+  cni_version: v1.4.0
+  cni_sha256: 890e00a8ffc71c860e4f09ab4e1c452d85ec18cc4ac8ee3da11bbfc113355f5e
+  cni_sha512: d812663fb58cfa2bfe35dd70940586d47f11feddd35a86ea7639197b022f9c0e0f487679e2e968eebf1f80b8b1d9cfbd0fe99d80590ae60a8128fa393d713e0b
 
   # renovate: datasource=github-tags depName=containerd/containerd
   containerd_version: v1.7.10
@@ -68,9 +68,9 @@ vars:
   ipxe_sha512: 00dc6f925e3b3f6a92b7b6fc1733a3c022b3af7c11b1c0dd8a36fb383a912fc3f7861fcafbaf385ef8f2bc41da147252ac329faf9c88bdc67d770446fc9bae99
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 6.1.64
-  linux_sha256: 629daa38f3ea67f29610bfbd53f9f38f46834d3654451e9474100490c66dc7e7
-  linux_sha512: 84ea64fab869ce3929b90862094d9ca762c3c1cec1ae8c3f7191d33efc4f1ad5ab4f89d2b69b142d5893f17475099e7e4b7f124edf7c0eee2638fa6202fb3d6d
+  linux_version: 6.1.65
+  linux_sha256: 407229936802a44b1e484c2e9ac3bbe53a65d825cc468ccdbd76281b491ab20a
+  linux_sha512: e56dc54fb12f1fbc696dbac9d3f0f53084232e54861e91703c3e802981c0770d4be2b0df854be606e7c5c38d60a3300882f846e721d778ded0984291724b9919
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git
   kmod_version: 31
@@ -103,9 +103,9 @@ vars:
   libpopt_sha512: 5d1b6a15337e4cd5991817c1957f97fc4ed98659870017c08f26f754e34add31d639d55ee77ca31f29bb631c0b53368c1893bd96cf76422d257f7997a11f6466
 
   # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=seccomp/libseccomp
-  libseccomp_version: 2.5.4
-  libseccomp_sha256: d82902400405cf0068574ef3dc1fe5f5926207543ba1ae6f8e7a1576351dcbdb
-  libseccomp_sha512: 92650bd7d1d48b383f402a536b97a017fd0f6ad1234daf4b938d01c92e8d134a01d2f2dd45fd9e2d025d7556bd1386ec360402145a87f20580c85949d62cea0e
+  libseccomp_version: 2.5.5
+  libseccomp_sha256: 248a2c8a4d9b9858aa6baf52712c34afefcf9c9e94b76dce02c1c9aa25fb3375
+  libseccomp_sha512: f630e7a7e53a21b7ccb4d3e7b37616b89aeceba916677c8e3032830411d77a14c2d74dcf594cd193b1acc11f52595072e28316dc44300e54083d5d7b314a38da
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.liburcu.org/userspace-rcu.git
   liburcu_version: 0.14.0
@@ -178,9 +178,9 @@ vars:
   uboot_sha512: 417a28267eb7875820d08fafc7316f164663609378637539e71648b0b9b7d28796b6c381717f31b0ab6472805fefd32628ef7d1b2e7b9f3c51c8ad122993f679
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git
-  util_linux_version: 2.39.2
-  util_linux_sha256: 87abdfaa8e490f8be6dde976f7c80b9b5ff9f301e1b67e3899e1f05a59a1531f
-  util_linux_sha512: cebecdd62749d0aeea2c4faf7ad1606426eff03ef3b15cd9c2df1126f216a4ed546d8fc3218c649fa95944eb87a98bb6a7cdd0bea31057c481c5cf608ffc19a3
+  util_linux_version: 2.39.3
+  util_linux_sha256: 7b6605e48d1a49f43cc4b4cfc59f313d0dd5402fa40b96810bd572e167dfed0f
+  util_linux_sha512: a2de1672f06ca5d2d431db1265a8499808770c3781019ec4a3a40170df4685826d8e3ca120841dcc5df4681ca8c935a993317bd0dc70465b21bf8e0efef65afa
 
   # DO NOT bump above 5.18.*, as in newer versions filesystems smaller than 300MB are not supported (i.e. Talos STATE partition).
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git

--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 6.1.64 Kernel Configuration
+# Linux/x86 6.1.65 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 13.2.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.1.64 Kernel Configuration
+# Linux/arm64 6.1.65 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 13.2.0"
 CONFIG_CC_IS_GCC=y


### PR DESCRIPTION
Also other bumps:

| Package | Update | Change |
|---|---|---|
| [containernetworking/plugins](https://togithub.com/containernetworking/plugins) | minor | `v1.3.0` -> `v1.4.0` |
| git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git | patch | `6.1.64` -> `6.1.65` |
| git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git | patch | `2.39.2` -> `2.39.3` |
| [seccomp/libseccomp](https://togithub.com/seccomp/libseccomp) | patch | `2.5.4` -> `2.5.5` |
