### PR TITLE
fix: zfs module build

### DIFF
--- a/zfs/pkg.yaml
+++ b/zfs/pkg.yaml
@@ -26,9 +26,7 @@ steps:
         cp /src/modules.builtin /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
         cp /src/modules.builtin.modinfo /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
 
-        for i in $(find $(pwd)/module/ -mindepth 1 -maxdepth 1 -type d); do
-          make -j $(nproc) -C /src M="$i" modules_install DESTDIR=/rootfs INSTALL_MOD_PATH=/rootfs INSTALL_MOD_DIR=extras INSTALL_MOD_STRIP=1 CONFIG_MODULE_SIG_ALL=y
-        done
+        make -j $(nproc) -C /src M="$(pwd)/module" modules_install DESTDIR=/rootfs INSTALL_MOD_PATH=/rootfs INSTALL_MOD_DIR=extras INSTALL_MOD_STRIP=1 CONFIG_MODULE_SIG_ALL=y
     test:
       - |
         # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping


### PR DESCRIPTION
Since zfs moved all modules to `zfs` and `spl`, the build step needs to be updated.