### PR TITLE
feat: add perf tool package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ TARGETS += linux-firmware
 TARGETS += lvm2
 TARGETS += musl
 TARGETS += openssl
+TARGETS += perf
 TARGETS += raspberrypi-firmware
 TARGETS += runc
 TARGETS += sd-boot

--- a/perf/pkg.yaml
+++ b/perf/pkg.yaml
@@ -1,0 +1,21 @@
+name: perf
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: kernel-prepare
+steps:
+  - build:
+      - |
+        cd /src
+        make -C tools/perf
+    install:
+      - |
+        mkdir /rootfs
+        cd /src
+        make -C tools/perf install DESTDIR=/rootfs
+    test:
+      - |
+        ls -l /rootfs/bin/perf
+finalize:
+  - from: /rootfs
+    to: /


### PR DESCRIPTION
Add perf linux tool from the same kernel version used by Talos.

Useful to diag/debug using a privileged containers that as full control of the node. 

```
    securityContext:
          allowPrivilegeEscalation: true
          privileged: true
    volumeMounts:
          - name: hostfs
            mountPath: /rootfs
...
hostIPC: true
hostPID: true
hostNetwork: true
volumes:
    - name: hostfs
      hostPath:
          path: /
```