### PR TITLE
chore: remove symlinks and broken binaries

### DIFF
--- a/iptables/pkg.yaml
+++ b/iptables/pkg.yaml
@@ -21,6 +21,9 @@ steps:
         --disable-nftables \
         --enable-libipq \
         --with-xtlibdir=/lib/xtables
+
+        rm -f /sbin/iptables-apply \
+              /sbin/ip6tables-apply
     build:
       - |
         make -j $(nproc)

--- a/lvm2/pkg.yaml
+++ b/lvm2/pkg.yaml
@@ -37,6 +37,56 @@ steps:
              --enable-udev_rules \
              --enable-static_link \
              --with-udev-prefix=/usr
+
+        rm -f /sbin/blkdeactivate \
+              /sbin/fsadm \
+              /sbin/fsck.xfs \
+              /sbin/lvchange \
+              /sbin/lvconvert \
+              /sbin/lvcreate \
+              /sbin/lvdisplay \
+              /sbin/lvextend \
+              /sbin/lvmconfig \
+              /sbin/lvmdevices \
+              /sbin/lvmdiskscan \
+              /sbin/lvmdump \
+              /sbin/lvm_import_vdo \
+              /sbin/lvmsadc \
+              /sbin/lvmsar \
+              /sbin/lvreduce \
+              /sbin/lvremove \
+              /sbin/lvrename \
+              /sbin/lvresize \
+              /sbin/lvs \
+              /sbin/lvscan \
+              /sbin/pvchange \
+              /sbin/pvck \
+              /sbin/pvcreate \
+              /sbin/pvdisplay \
+              /sbin/pvmove \
+              /sbin/pvremove \
+              /sbin/pvresize \
+              /sbin/pvs \
+              /sbin/pvscan \
+              /sbin/vgcfgbackup \
+              /sbin/vgcfrestore \
+              /sbin/vgchange \
+              /sbin/vgck \
+              /sbin/vgconvert \
+              /sbin/vgcreate \
+              /sbin/vgdisplay \
+              /sbin/vgexport \
+              /sbin/vgimport \
+              /sbin/vgimportclone \
+              /sbin/vgimportdevices \
+              /sbin/vgmerge \
+              /sbin/vgmknodes \
+              /sbin/vgreduce \
+              /sbin/vgremove \
+              /sbin/vgrename \
+              /sbin/vgs \
+              /sbin/vgscan \
+              /sbin/vgsplit
     build:
       - |
         make -j $(nproc)


### PR DESCRIPTION
Removes binaries that rely on bash or are symlinked to lvm