### PR TITLE
fix: enable KFD support in kernel

### DIFF
--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -3777,7 +3777,7 @@ CONFIG_DRM_AMD_DC_DCN=y
 # CONFIG_DRM_AMD_SECURE_DISPLAY is not set
 # end of Display Engine Configuration
 
-# CONFIG_HSA_AMD is not set
+CONFIG_HSA_AMD=y
 # CONFIG_DRM_NOUVEAU is not set
 CONFIG_DRM_I915=y
 CONFIG_DRM_I915_FORCE_PROBE=""


### PR DESCRIPTION
AMD KFD support was not enabled in Kconfig.

Ref: https://cateee.net/lkddb/web-lkddb/HSA_AMD.html

Fixes: #892
Fixes: https://github.com/siderolabs/extensions/issues/307

Signed-off-by: Noel Georgi <git@frezbo.dev>
(cherry picked from commit 65006ed198f31e97a77ddfded52043182f2c6e92)