### PR TITLE
feat(intel): add support for power management and ACPI options for Intel CPUs

### DIFF
--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -659,7 +659,7 @@ CONFIG_CPU_IDLE_GOV_HALTPOLL=y
 CONFIG_HALTPOLL_CPUIDLE=y
 # end of CPU Idle
 
-# CONFIG_INTEL_IDLE is not set
+CONFIG_INTEL_IDLE=y
 # end of Power management and ACPI options
 
 #


### PR DESCRIPTION
This should resolve #941 and address https://github.com/siderolabs/talos/issues/8595 .

Before:
![2024-04-18-223818_1671x563_scrot](https://github.com/siderolabs/pkgs/assets/150545/43be1aa2-9296-47ac-ae97-a2936482baf5)

After:
![2024-04-19-001841_1683x631_scrot](https://github.com/siderolabs/pkgs/assets/150545/c41b5f10-165c-4670-8fc1-0dceed56fbd7)

However I'm not sure how it will affect AMD CPUs - I assume this option will be ignored?