### PR TITLE
feat: add 'apparmor' package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-28T12:19:20Z by kres a914cae.
+# Generated on 2024-06-25T05:52:46Z by kres 4c9f215.
 
 name: default
 concurrency:
@@ -33,7 +33,7 @@ jobs:
       labels: ${{ steps.retrieve-pr-labels.outputs.result }}
     services:
       buildkitd:
-        image: moby/buildkit:v0.13.2
+        image: moby/buildkit:v0.14.0
         options: --privileged
         ports:
           - 1234:1234
@@ -135,7 +135,7 @@ jobs:
       - default
     services:
       buildkitd:
-        image: moby/buildkit:v0.13.2
+        image: moby/buildkit:v0.14.0
         options: --privileged
         ports:
           - 1234:1234

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-28T12:19:20Z by kres a914cae.
+# Generated on 2024-06-25T05:52:46Z by kres 4c9f215.
 
 name: weekly
 concurrency:
@@ -16,7 +16,7 @@ jobs:
       - pkgs
     services:
       buildkitd:
-        image: moby/buildkit:v0.13.2
+        image: moby/buildkit:v0.14.0
         options: --privileged
         ports:
           - 1234:1234

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -3,6 +3,7 @@ kind: pkgfile.Build
 spec:
   targets:
     # - non-related to the kernel, in alphabetical order
+    - apparmor
     - base
     - ca-certificates
     - cni

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-28T12:19:20Z by kres a914cae.
+# Generated on 2024-06-25T05:52:46Z by kres 4c9f215.
 
 # common variables
 
@@ -44,7 +44,8 @@ COMMON_ARGS += --build-arg=SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH)
 
 # targets defines all the available targets
 
-TARGETS = base
+TARGETS = apparmor
+TARGETS += base
 TARGETS += ca-certificates
 TARGETS += cni
 TARGETS += containerd

--- a/Pkgfile
+++ b/Pkgfile
@@ -173,5 +173,10 @@ vars:
   zfs_version: 2.2.4
   zfs_sha256: 9790905f7683d41759418e1ef3432828c31116654ff040e91356ff1c21c31ec0
   zfs_sha512: 1d17e30573d594fb5c9ea77cde104616dca362fed7530296816d1b55173594f66170fcfb23ab57c27074f85b79d3eb557b4ee9a1c420e507b2434a7902d8dcc1
+
+  # renovate: datasource=git-tags depName=https://gitlab.com/apparmor/apparmor.git
+  apparmor_version: v3.1.7
+  apparmor_sha256: 64494bd99fa6547a9cbdb4fc6bc732451a02dd19e6eb70eab977b239632151eb
+  apparmor_sha512: cfd6b0afb98d4559c16a6a2e23ca16ee9d86325fc6059313df5d3e8feba3d398f96a5754d3880dd2cafb2e7b1a06bd789d62cd36aaf993e46290f6311bb49dac
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/pkgs

--- a/apparmor/pkg.yaml
+++ b/apparmor/pkg.yaml
@@ -1,0 +1,38 @@
+name: apparmor
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+  - stage: util-linux
+steps:
+  - sources:
+      - url: https://gitlab.com/apparmor/apparmor/-/archive/{{ .apparmor_version }}/apparmor-{{ .apparmor_version }}.tar.gz
+        destination: apparmor.tar.gz
+        sha256: "{{ .apparmor_sha256 }}"
+        sha512: "{{ .apparmor_sha512 }}"
+    prepare:
+      - |
+        tar -xzf apparmor.tar.gz --strip-components=1
+
+        mkdir -p /usr/bin \
+            && ln -sf /toolchain/bin/env /usr/bin/env
+        ln -s /toolchain/bin/echo /toolchain/bin/which
+        ln -s /toolchain/include/linux /usr/include/linux
+
+        cd libraries/libapparmor
+        ./autogen.sh
+        ./configure --disable-dependency-tracking --disable-man-pages
+    build:
+      - |
+        cd libraries/libapparmor
+        make -j $(nproc)
+        
+        cd ../../parser        
+        make arch -j $(nproc)
+    install:
+      - |
+        cd parser
+        DISTRO=unknown make install-arch DESTDIR=/rootfs
+finalize:
+  - from: /rootfs
+    to: /

--- a/reproducibility/pkg.yaml
+++ b/reproducibility/pkg.yaml
@@ -1,6 +1,7 @@
 name: reproducibility
 variant: scratch
 dependencies:
+  - stage: apparmor
   # base is not needed since it's toolchain modified with a local musl build, we're only interested in the reproducibility of files that go into talos
   # - stage: base
   # ca-certificates can be ignored from reproducibility test since it's a file downloaded and extracted (no build happens)


### PR DESCRIPTION
 Include AppArmor userland tool /sbin/apparmor_parser in rootfs to enable AppArmor support in containerd

As discussed in https://github.com/siderolabs/talos/issues/8715