### PR TITLE
feat: update xfsprogs 6.10.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ TARGETS += iptables
 TARGETS += ipxe
 TARGETS += kmod
 TARGETS += libaio
+TARGETS += libattr
 TARGETS += libinih
 TARGETS += libjson-c
 TARGETS += liblzma
@@ -203,4 +204,3 @@ release-notes: $(ARTIFACTS)
 conformance:
 	@docker pull $(CONFORMANCE_IMAGE)
 	@docker run --rm -it -v $(PWD):/src -w /src $(CONFORMANCE_IMAGE) enforce
-

--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.8.0-1-ga0c06c6
+  TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.9.0-alpha.0-2-g9f2189b
 
   # renovate: datasource=github-releases depName=containernetworking/plugins
   cni_version: v1.5.1
@@ -81,6 +81,11 @@ vars:
   libaio_version: 0.3.113
   libaio_sha256: 2c44d1c5fd0d43752287c9ae1eb9c023f04ef848ea8d4aafa46e9aedb678200b
   libaio_sha512: 65c30a102433bf8386581b03fc706d84bd341be249fbdee11a032b237a7b239e8c27413504fef15e2797b1acd67f752526637005889590ecb380e2e120ab0b71
+
+  # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.savannah.gnu.org/attr.git
+  libattr_version: 2.5.2
+  libattr_sha256: f2e97b0ab7ce293681ab701915766190d607a1dba7fae8a718138150b700a70b
+  libattr_sha512: f587ea544effb7cfed63b3027bf14baba2c2dbe3a9b6c0c45fc559f7e8cb477b3e9a4a826eae30f929409468c50d11f3e7dc6d2500f41e1af8662a7e96a30ef3
 
   # renovate: datasource=github-releases extractVersion=^r(?<version>.*)$ depName=benhoyt/inih
   libinih_version: 58
@@ -167,9 +172,9 @@ vars:
   util_linux_sha512: ffe20b915a518a150401d429b0338bc7022190e4ca0ef91a6d9eea345db8c1e11ad01784163b8fcf978506f3f5cad473f29d5d4ef93a4c66a5ae0ebd9fb0c8f2
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git
-  xfsprogs_version: 6.9.0
-  xfsprogs_sha256: 975284783fb3fbc4e1ae640bd804d788e4237a86b07582acee86b6e48f6521b7
-  xfsprogs_sha512: c597453759c400690810971f0b2daf0e4e22c74270b0f9800e2235da5e5c1383b59bc1176c5bba0023f74b623020fb51c62f0e98a74885cf3a8336e0b81c9023
+  xfsprogs_version: 6.10.1
+  xfsprogs_sha256: 6cb839be1a9535f8352441b3f6eea521ead5c5c7c913e8106cdfac96aa117041
+  xfsprogs_sha512: b9fd7b7eaf038772ee4a9602bf38f714db7077731ec8904e0959d28b0103d443be8ae67720869012b90737c1ff440fbce44b3b23b662939c9a90c6d3be3fab08
 
   # renovate: datasource=github-tags extractVersion=^zfs-(?<version>.*)$ depName=openzfs/zfs
   zfs_version: 2.2.6

--- a/libattr/pkg.yaml
+++ b/libattr/pkg.yaml
@@ -1,0 +1,39 @@
+name: libattr
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+steps:
+  - sources:
+      - url: https://src.fedoraproject.org/repo/extras/rpms/rpms/attr/attr-{{ .libattr_version }}.tar.xz/sha512/f587ea544effb7cfed63b3027bf14baba2c2dbe3a9b6c0c45fc559f7e8cb477b3e9a4a826eae30f929409468c50d11f3e7dc6d2500f41e1af8662a7e96a30ef3/attr-{{ .libattr_version }}.tar.xz
+        # url: https://download.savannah.nongnu.org/releases/attr/attr-{{ .libattr_version }}.tar.gz
+        destination: attr.tar.xz
+        sha256: "{{ .libattr_sha256 }}"
+        sha512: "{{ .libattr_sha512 }}"
+    prepare:
+      - |
+        tar -xf attr.tar.xz --strip-components=1
+
+        OPTIMIZER="$CFLAGS" \
+        DEBUG=-DNDEBUG \
+        INSTALL_USER=root \
+        INSTALL_GROUP=root \
+        ./configure \
+          --prefix=/ \
+          --exec-prefix=/ \
+          --sbindir=/bin \
+          --bindir=/usr/bin \
+          --libdir=/lib \
+          --libexecdir=/usr/lib \
+          --includedir=/usr/include \
+          --disable-manpages \
+          --disable-nls
+    build:
+      - |
+        make -j $(nproc)
+    install:
+      - |
+        make install DESTDIR=/rootfs
+finalize:
+  - from: /rootfs
+    to: /

--- a/xfsprogs/pkg.yaml
+++ b/xfsprogs/pkg.yaml
@@ -4,6 +4,7 @@ shell: /toolchain/bin/bash
 dependencies:
   - stage: base
   - stage: util-linux
+  - stage: libattr
   - stage: libinih
   - stage: liburcu
 steps:
@@ -13,7 +14,6 @@ steps:
         sha256: "{{ .xfsprogs_sha256 }}"
         sha512: "{{ .xfsprogs_sha512 }}"
     env:
-      DEBUG: "-DNDEBUG"
       # musl >=1.2.4 requires _LARGEFILE64_SOURCE for LFS64 interfaces support:
       # https://www.openwall.com/lists/musl/2023/05/02/1
       CFLAGS: "-D_LARGEFILE64_SOURCE"
@@ -28,7 +28,7 @@ steps:
         --enable-gettext=no
     build:
       - |
-        make -j $(nproc) DEBUG=-DNDEBUG
+        make -j $(nproc)
     install:
       - |
         make install DESTDIR=/rootfs


### PR DESCRIPTION
It's not quite evident why libattr started to be a hard dependency in 6.10.

Do we need to drop some progs we don't use?

Probably needs libattr in Talos rootfs as well.