### PR TITLE
feat: bump releases

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -17,9 +17,9 @@ vars:
   containerd_sha512: 6296ee92976228fc86511b690c98b164a41ac1f30caaffb486e27729ee850ce8034ad5f3c08025cb9e33617bfa883b8ec8b9df4f9b2a3a289a9a305d6d2e9c57
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/cryptsetup/cryptsetup.git
-  cryptsetup_version: 2.7.4
-  cryptsetup_sha256: 2cee74381c537ab5b40afad807fe196efde112522dc9a6acae81b3082a744da7
-  cryptsetup_sha512: 92f0ca306c03b35bef1043ed7bcf1cd57d4118d21a2437ab51ede983901b29c340a138f71a258d3c6a099f821e9bdb2ae712642cc2208c21bbc8faf6b0d1bfb8
+  cryptsetup_version: 2.7.5
+  cryptsetup_sha256: f2c6d22e53435de5d35dc9fdc86600d3e5e2227d27970b07a8e6a0f9f7bd42ac
+  cryptsetup_sha512: 1c2752baacca9c3ae6c507b9e86a0b31ee8b3d508d4233292ad3df432679b875810a4bef93eaa680e58203b04ca30e8e215c91a8a83d2c61905180633c372edf
 
   # renovate: datasource=github-releases extractVersion=^v(?<version>.*)$ depName=dosfstools/dosfstools
   dosfstools_version: 4.2
@@ -63,14 +63,14 @@ vars:
   iptables_sha512: 71e6ed2260859157d61981a4fe5039dc9e8d7da885a626a4b5dae8164c509a9d9f874286b9468bb6a462d6e259d4d32d5967777ecefdd8a293011ae80c00f153
 
   # renovate: datasource=git-refs versioning=git depName=https://github.com/ipxe/ipxe.git
-  ipxe_ref: 748cab7745186ec6c770fb4d47b0e8c9f213e6df
-  ipxe_sha256: 230bbe9c6ce42295fa514b99e0fcb4066bfe783051ff418456fc554b6c6b6507
-  ipxe_sha512: 001c10a81ca232f3656930ad8476ce3d1dbf117c49f45f84ba0a4f58668239d0cf0ab6a510955ac77b3e608cbf96367194ab3fc58a9efe3f8f3c9b5d12fb8348
+  ipxe_ref: c7f2e75519986f5847ba14ccd0e9b846c138aaaf
+  ipxe_sha256: 117bbe9c0e0b24bdfb86a7e76c9351a0ca10dca75f4a4126c23af386b860cab8
+  ipxe_sha512: 3f9fce7d9c78fcaff7663502cf797e4045c2593d1d23a4abf6db688e443173ca43cc5f960b69ecd9364591062dfde088f99aa3625cd87cbfffcab1fad1166a59
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 6.6.47
-  linux_sha256: d43376c9e9eaa92bb1b926054bd160d329c58a62d64bd65fe1222c11c6564f50
-  linux_sha512: 9a3c52f5df4480a61493ca24d25c9e9b5b9dfe2e465ecf7d457bc240abf88b2d08d745b63895c6b47a557fca610882bbc8b5fe66b2d7a9262f548daca50d4004
+  linux_version: 6.6.49
+  linux_sha256: 2c56dac2b70859c16b4ef651befb0d28c227498bd3eee08e8a45a357f22dd3b7
+  linux_sha512: 3db87b48dd3b771cd119cf48f9fbad43cfe2f90e34bb06419a25068a6807c294d2019089a21471b72c1438f45a84d99ecf77d322ef85b3e2815c7dedc6f41bd8
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git
   kmod_version: 33
@@ -146,10 +146,10 @@ vars:
   openssl_sha512: d3682a5ae0721748c6b9ec2f1b74d2b1ba61ee6e4c0d42387b5037a56ef34312833b6abb522d19400b45d807dd65cc834156f5e891cb07fbaf69fcf67e1c595d
 
   # renovate: datasource=github-tags depName=opencontainers/runc
-  runc_version: v1.2.0-rc.2
-  runc_ref: f2d2ee5e45af3c9b38dfd639ac92f43c3055ce4e
-  runc_sha256: 293b7271196a7284a1cca1865e8e210d9c153054b0d0c04f3a69f28ca517723d
-  runc_sha512: 13739045e0a7a479ece0696eba852a89b51c4e900c5f694175e603c7147eec8826abc16ce11a4b64ff51d002898f5d776afb454894a101fa2106ab04d2e06658
+  runc_version: v1.2.0-rc.3
+  runc_ref: 45471bc945571d57acef05e0795008d7f1d9baf5
+  runc_sha256: 837185e9041c795187eb0f775af8d0b76869e98376bad7cf5f3249a2c636e794
+  runc_sha512: b8550ea4bebb5efdf4eb09273b1d8dbf7ad3c5fac59d4f057100e52a2054151e1ca4463f437a7840e5c5473058d4d8598ff039f79d03862a06a2b9e15678e3de
 
   # renovate: datasource=git-tags extractVersion=^tag-(?<version>.*)$ depName=git://repo.or.cz/socat.git
   socat_version: 1.8.0.1

--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 6.6.47 Kernel Configuration
+# Linux/x86 6.6.49 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 13.3.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.6.47 Kernel Configuration
+# Linux/arm64 6.6.49 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 13.3.0"
 CONFIG_CC_IS_GCC=y

--- a/runc/pkg.yaml
+++ b/runc/pkg.yaml
@@ -16,7 +16,6 @@ steps:
       GO: /toolchain/go/bin/go
       PKG_CONFIG_PATH: /usr/lib/pkgconfig
       CC: /toolchain/bin/cc
-      VERSION: {{ .runc_version }}
       PATH: /toolchain/go/bin:/toolchain/bin:/bin
     prepare:
       - |
@@ -29,7 +28,7 @@ steps:
 
         ldflags="-w -s -buildid="
 
-        make COMMIT_NO= COMMIT={{ .runc_ref }} EXTRA_FLAGS="-a" EXTRA_LDFLAGS="${ldflags}" static
+        make COMMIT_NO= COMMIT={{ .runc_ref }} EXTRA_FLAGS="-a" EXTRA_LDFLAGS="${ldflags}" VERSION="{{ .runc_version }}" static
     install:
       - |
         cd runc


### PR DESCRIPTION
| Package | Update | Change |
|---|---|---|
| git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git | patch | `6.6.47` -> `6.6.49` |
| git://git.kernel.org/pub/scm/utils/cryptsetup/cryptsetup.git | patch | `2.7.4` -> `2.7.5` |
| https://github.com/ipxe/ipxe.git | digest | `748cab7` -> `c7f2e75` |
| [opencontainers/runc](https://redirect.github.com/opencontainers/runc) | patch | `v1.2.0-rc.2` -> `v1.2.0-rc.3` |

runc update: https://github.com/opencontainers/runc/releases/tag/v1.2.0-rc.3

Fix CVE-2024-45310, a low-severity attack that allowed maliciously configured containers to create empty files and directories on the host.