### PR TITLE
fix: lvm2 modprobe path

### DIFF
--- a/lvm2/pkg.yaml
+++ b/lvm2/pkg.yaml
@@ -36,7 +36,8 @@ steps:
              --enable-udev_sync \
              --enable-udev_rules \
              --enable-static_link \
-             --with-udev-prefix=/usr
+             --with-udev-prefix=/usr \
+             MODPROBE_CMD=/sbin/modprobe
 
         rm -f /sbin/blkdeactivate \
               /sbin/fsadm \


### PR DESCRIPTION
LVM2 configure uses `AC_PATH_TOOL` to find modprobe path if not set, as we're building inside tools it was picking up `/toolchain/bin/modprobe`. Explicitly set `MODPROBE_CMD=/sbin/modprobe` to the path of `modprobe` binary in talos.

Fixes: https://github.com/siderolabs/talos/issues/9300