### PR TITLE
fix: force LVM to use `/run` as state directory

### DIFF
--- a/lvm2/pkg.yaml
+++ b/lvm2/pkg.yaml
@@ -26,6 +26,8 @@ steps:
         export PKG_CONFIG_PATH=/usr/lib/pkgconfig
 
         ./configure \
+             --with-default-run-dir=/run/lvm \
+             --with-default-locking-dir=/run/lock/lvm \
              --with-thin=internal \
              --with-cache=none \
              --disable-udev-systemd-background-jobs \


### PR DESCRIPTION
See https://github.com/siderolabs/talos/issues/9365

This allows to break dependency on `/var` availability, and also workaround issue with `/var/run` being persistent on Talos right now (which is going to be fixed as well).