### PR TITLE
fix: drop the LVM2 udev lvm rule

### DIFF
--- a/lvm2/pkg.yaml
+++ b/lvm2/pkg.yaml
@@ -99,6 +99,9 @@ steps:
     install:
       - |
         make DESTDIR=/rootfs install
+
+        # LVM activation is handled by Talos itself
+        rm -f /rootfs/usr/lib/udev/rules.d/69-dm-lvm.rules
 finalize:
   - from: /rootfs
     to: /


### PR DESCRIPTION
This rule depends on `systemd-run`, and it won't work in Talos anyways, but it conflicts with Talos activating LVM volumes, as the call to `pvscan` updates the cache as if the volume got already activated, while in fact it hasn't been activated yet.