### PR TITLE
fix: libselinux: support running without /etc/selinux

### DIFF
--- a/libselinux/patches/0001-libselinux-exclude-requirement-for-etc-selinux.patch
+++ b/libselinux/patches/0001-libselinux-exclude-requirement-for-etc-selinux.patch
@@ -1,0 +1,46 @@
+From d759ab08ab7cfa88afb5fcac749b08e8e26aeab3 Mon Sep 17 00:00:00 2001
+From: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
+Date: Fri, 4 Oct 2024 21:08:24 +0200
+Subject: [PATCH] libselinux: exclude requirement for /etc/selinux
+
+We don't use this directory in Talos but load a policy embedded in the init binary
+
+Signed-off-by: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
+---
+ src/enabled.c | 4 ----
+ src/init.c    | 3 ---
+ 2 files changed, 7 deletions(-)
+
+diff --git a/src/enabled.c b/src/enabled.c
+index fefb0bd9..3e56f981 100644
+--- a/src/enabled.c
++++ b/src/enabled.c
+@@ -13,11 +13,7 @@ int is_selinux_enabled(void)
+ 	/* init_selinuxmnt() gets called before this function. We
+  	 * will assume that if a selinux file system is mounted, then
+  	 * selinux is enabled. */
+-#ifdef ANDROID
+ 	return (selinux_mnt ? 1 : 0);
+-#else
+-	return (selinux_mnt && has_selinux_config);
+-#endif
+ }
+ 
+ 
+diff --git a/src/init.c b/src/init.c
+index 542c979b..46a83bfb 100644
+--- a/src/init.c
++++ b/src/init.c
+@@ -148,9 +148,6 @@ static void init_lib(void)
+ {
+ 	selinux_page_size = sysconf(_SC_PAGE_SIZE);
+ 	init_selinuxmnt();
+-#ifndef ANDROID
+-	has_selinux_config = (access(SELINUXCONFIG, F_OK) == 0);
+-#endif
+ }
+ 
+ static void fini_lib(void) __attribute__ ((destructor));
+-- 
+2.46.1
+

--- a/libselinux/patches/0001-libselinux-set-free-d-data-to-NULL.patch
+++ b/libselinux/patches/0001-libselinux-set-free-d-data-to-NULL.patch
@@ -1,0 +1,78 @@
+From f398662ea19d2cf6db6cb791e3b787889e5af883 Mon Sep 17 00:00:00 2001
+From: Petr Lautrbach <lautrbach@redhat.com>
+Date: Tue, 9 Jul 2024 21:23:46 +0200
+Subject: [PATCH] libselinux: set free'd data to NULL
+
+Fixes segfault in selabel_open() on systems with SELinux disabled and without any
+SELinux policy installed introduced by commit 5876aca0484f ("libselinux: free
+data on selabel open failure"):
+
+    $ sestatus
+    SELinux status:                 disabled
+
+    $ cat /etc/selinux/config
+    cat: /etc/selinux/config: No such file or directory
+
+    $ matchpathcon /abc
+    [1]    907999 segmentation fault (core dumped)  matchpathcon /abc
+
+Signed-off-by: Petr Lautrbach <lautrbach@redhat.com>
+Acked-by: James Carter <jwcart2@gmail.com>
+---
+ src/label_backends_android.c | 1 +
+ src/label_file.c             | 1 +
+ src/label_media.c            | 1 +
+ src/label_x.c                | 1 +
+ 4 files changed, 4 insertions(+)
+
+diff --git a/src/label_backends_android.c b/src/label_backends_android.c
+index 49a87686..5bad24f2 100644
+--- a/src/label_backends_android.c
++++ b/src/label_backends_android.c
+@@ -260,6 +260,7 @@ static void closef(struct selabel_handle *rec)
+ 		free(data->spec_arr);
+ 
+ 	free(data);
++	rec->data = NULL;
+ }
+ 
+ static struct selabel_lookup_rec *property_lookup(struct selabel_handle *rec,
+diff --git a/src/label_file.c b/src/label_file.c
+index 2732972e..59c9f2ef 100644
+--- a/src/label_file.c
++++ b/src/label_file.c
+@@ -942,6 +942,7 @@ static void closef(struct selabel_handle *rec)
+ 		free(last_area);
+ 	}
+ 	free(data);
++	rec->data = NULL;
+ }
+ 
+ // Finds all the matches of |key| in the given context. Returns the result in
+diff --git a/src/label_media.c b/src/label_media.c
+index 852aeada..bae065c1 100644
+--- a/src/label_media.c
++++ b/src/label_media.c
+@@ -183,6 +183,7 @@ static void close(struct selabel_handle *rec)
+ 	    free(spec_arr);
+ 
+ 	free(data);
++	rec->data = NULL;
+ }
+ 
+ static struct selabel_lookup_rec *lookup(struct selabel_handle *rec,
+diff --git a/src/label_x.c b/src/label_x.c
+index a8decc7a..ddae4f6c 100644
+--- a/src/label_x.c
++++ b/src/label_x.c
+@@ -210,6 +210,7 @@ static void close(struct selabel_handle *rec)
+ 	    free(spec_arr);
+ 
+ 	free(data);
++	rec->data = NULL;
+ }
+ 
+ static struct selabel_lookup_rec *lookup(struct selabel_handle *rec,
+-- 
+2.46.1
+

--- a/libselinux/pkg.yaml
+++ b/libselinux/pkg.yaml
@@ -17,6 +17,9 @@ steps:
 
         patch -p1 < /pkg/patches/musl-lstat.patch
         patch -p1 < /pkg/patches/selabel-digest-uninit.patch
+        patch -p1 < /pkg/patches/0001-libselinux-exclude-requirement-for-etc-selinux.patch
+        # TODO: remove upstream patches when updating to 3.8
+        patch -p1 < /pkg/patches/0001-libselinux-set-free-d-data-to-NULL.patch
     build:
       - |
         make -j $(nproc) FTS_LDLIBS="-l:libfts.a -L/toolchain/lib"

--- a/libsepol/patches/0001-libsepol-cil-Check-that-sym_index-is-within-bounds.patch
+++ b/libsepol/patches/0001-libsepol-cil-Check-that-sym_index-is-within-bounds.patch
@@ -1,0 +1,40 @@
+From 6b5626fd30292b148fa8b732a38a03af1705b655 Mon Sep 17 00:00:00 2001
+From: Vit Mojzis <vmojzis@redhat.com>
+Date: Tue, 23 Jul 2024 16:41:57 +0200
+Subject: [PATCH] libsepol/cil: Check that sym_index is within bounds
+
+Make sure sym_index is within the bounds of symtab array before using it
+to index the array.
+
+Fixes:
+  Error: OVERRUN (CWE-119):
+  libsepol-3.6/cil/src/cil_resolve_ast.c:3157: assignment: Assigning: "sym_index" = "CIL_SYM_UNKNOWN".
+  libsepol-3.6/cil/src/cil_resolve_ast.c:3189: overrun-call: Overrunning callee's array of size 19 by passing argument "sym_index" (which evaluates to 20) in call to "cil_resolve_name".
+  \# 3187|                   switch (curr->flavor) {
+  \# 3188|                   case CIL_STRING:
+  \# 3189|->                         rc = cil_resolve_name(parent, curr->data, sym_index, db, &res_datum);
+  \# 3190|                           if (rc != SEPOL_OK) {
+  \# 3191|                                   goto exit;
+
+Signed-off-by: Vit Mojzis <vmojzis@redhat.com>
+Acked-by: James Carter <jwcart2@gmail.com>
+---
+ cil/src/cil_resolve_ast.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cil/src/cil_resolve_ast.c b/cil/src/cil_resolve_ast.c
+index 427a320c..da8863c4 100644
+--- a/cil/src/cil_resolve_ast.c
++++ b/cil/src/cil_resolve_ast.c
+@@ -4291,7 +4291,7 @@ int cil_resolve_name_keep_aliases(struct cil_tree_node *ast_node, char *name, en
+ 	int rc = SEPOL_ERR;
+ 	struct cil_tree_node *node = NULL;
+ 
+-	if (name == NULL) {
++	if (name == NULL || sym_index >= CIL_SYM_NUM) {
+ 		cil_log(CIL_ERR, "Invalid call to cil_resolve_name\n");
+ 		goto exit;
+ 	}
+-- 
+2.46.1
+

--- a/libsepol/patches/0001-libsepol-sepol_compute_sid-Do-not-destroy-uninitiali.patch
+++ b/libsepol/patches/0001-libsepol-sepol_compute_sid-Do-not-destroy-uninitiali.patch
@@ -1,0 +1,51 @@
+From 1f080ffd7ab24b0ad2b46f79db63d62c2ae2747c Mon Sep 17 00:00:00 2001
+From: Vit Mojzis <vmojzis@redhat.com>
+Date: Fri, 19 Jul 2024 18:17:13 +0200
+Subject: [PATCH] libsepol/sepol_compute_sid: Do not destroy uninitialized
+ context
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Avoid context_destroy() on "newcontext" before context_init() is called.
+
+Fixes:
+  libsepol-3.6/src/services.c:1335: var_decl: Declaring variable "newcontext" without initializer.
+  libsepol-3.6/src/services.c:1462: uninit_use_in_call: Using uninitialized value "newcontext.range.level[0].cat.node" when calling "context_destroy".
+  \# 1460|   	rc = sepol_sidtab_context_to_sid(sidtab, &newcontext, out_sid);
+  \# 1461|         out:
+  \# 1462|-> 	context_destroy(&newcontext);
+  \# 1463|   	return rc;
+  \# 1464|   }
+
+Signed-off-by: Vit Mojzis <vmojzis@redhat.com>
+Reviewed-by: Christian Göttsche <cgzones@googlemail.com>
+Acked-by: Stephen Smalley <stephen.smalley.work@gmail.com>
+---
+ src/services.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/src/services.c b/src/services.c
+index 36e2368f..f3231f17 100644
+--- a/src/services.c
++++ b/src/services.c
+@@ -1362,14 +1362,12 @@ static int sepol_compute_sid(sepol_security_id_t ssid,
+ 	scontext = sepol_sidtab_search(sidtab, ssid);
+ 	if (!scontext) {
+ 		ERR(NULL, "unrecognized SID %d", ssid);
+-		rc = -EINVAL;
+-		goto out;
++		return -EINVAL;
+ 	}
+ 	tcontext = sepol_sidtab_search(sidtab, tsid);
+ 	if (!tcontext) {
+ 		ERR(NULL, "unrecognized SID %d", tsid);
+-		rc = -EINVAL;
+-		goto out;
++		return -EINVAL;
+ 	}
+ 
+ 	if (tclass && tclass <= policydb->p_classes.nprim)
+-- 
+2.46.1
+

--- a/libsepol/pkg.yaml
+++ b/libsepol/pkg.yaml
@@ -12,6 +12,9 @@ steps:
     prepare:
       - |
         tar -xzf libsepol.tar.gz --strip-components=1
+        # TODO: remove upstream patches when updating to 3.8
+        patch -p1 < /pkg/patches/0001-libsepol-sepol_compute_sid-Do-not-destroy-uninitiali.patch
+        patch -p1 < /pkg/patches/0001-libsepol-cil-Check-that-sym_index-is-within-bounds.patch
     build:
       - |
         make -j $(nproc)


### PR DESCRIPTION
We don't use this directory in Talos but load a policy embedded in the init binary.
Also carry upstream fixes for CWEs and a segfault happening in udev without /etc/selinux.

Signed-off-by: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
