### PR TITLE
fix: do not build unneeded utilities and man for SELinux libraries

### DIFF
--- a/libselinux/pkg.yaml
+++ b/libselinux/pkg.yaml
@@ -22,10 +22,10 @@ steps:
         patch -p1 < /pkg/patches/0001-libselinux-set-free-d-data-to-NULL.patch
     build:
       - |
-        make -j $(nproc) FTS_LDLIBS="-l:libfts.a -L/toolchain/lib"
+        make -j $(nproc) FTS_LDLIBS="-l:libfts.a -L/toolchain/lib" SUBDIRS="include src"
     install:
       - |
-        make install DESTDIR=/rootfs
+        make install DESTDIR=/rootfs SUBDIRS="include src"
 finalize:
   - from: /rootfs
     to: /

--- a/libsepol/patches/dont-build-utils.patch
+++ b/libsepol/patches/dont-build-utils.patch
@@ -1,0 +1,31 @@
+diff --git a/Makefile b/Makefile
+index 5b5d03e2..5744d7a4 100644
+--- a/Makefile
++++ b/Makefile
+@@ -4,26 +4,21 @@ export DISABLE_CIL
+ 
+ all: 
+ 	$(MAKE) -C src 
+-	$(MAKE) -C utils
+ 
+ install: 
+ 	$(MAKE) -C include install
+ 	$(MAKE) -C src install
+-	$(MAKE) -C utils install
+-	$(MAKE) -C man install
+ 
+ relabel:
+ 	$(MAKE) -C src relabel
+ 
+ clean:
+ 	$(MAKE) -C src clean
+-	$(MAKE) -C utils clean
+ 	$(MAKE) -C tests clean
+ 
+ indent:
+ 	$(MAKE) -C src $@
+ 	$(MAKE) -C include $@
+-	$(MAKE) -C utils $@
+ 
+ test:
+ 	$(MAKE) -C tests test

--- a/libsepol/pkg.yaml
+++ b/libsepol/pkg.yaml
@@ -15,6 +15,8 @@ steps:
         # TODO: remove upstream patches when updating to 3.8
         patch -p1 < /pkg/patches/0001-libsepol-sepol_compute_sid-Do-not-destroy-uninitiali.patch
         patch -p1 < /pkg/patches/0001-libsepol-cil-Check-that-sym_index-is-within-bounds.patch
+        # Do not build CLI utilities we do not use
+        patch -p1 < /pkg/patches/dont-build-utils.patch
     build:
       - |
         make -j $(nproc)


### PR DESCRIPTION
Utilities end up on rootfs increasing size and binary count

Fixes #1067

Signed-off-by: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
