### PR TITLE
chore: drop the -f flag for rm for udev build

### DIFF
--- a/systemd-udevd/pkg.yaml
+++ b/systemd-udevd/pkg.yaml
@@ -123,7 +123,7 @@ steps:
         cp --preserve=links /installroot/usr/lib/libudev.* /rootfs/usr/lib/
         # Already built this
         rm -rf /rootfs/usr/lib/udev/hwdb.d
-        rm -f /rootfs/usr/lib/udev/rules.d/{README,60-cdrom_id.rules,60-persistent-alsa.rules,60-persistent-v4l.rules,64-btrfs.rules,70-joystick.rules,70-mouse.rules,70-touchpad.rules,78-sound-card.rules,80-net-name-slot.rules,90-vconsole.rules,99-systemd.rules}
+        rm /rootfs/usr/lib/udev/rules.d/{README,60-cdrom_id.rules,60-persistent-alsa.rules,60-persistent-v4l.rules,64-btrfs.rules,70-joystick.rules,70-mouse.rules,70-touchpad.rules,78-sound-card.rules,90-vconsole.rules,99-systemd.rules}
         # Azure csi support
         cp /pkg/files/66-azure.rules /rootfs/usr/lib/udev/rules.d/66-azure.rules
 finalize:


### PR DESCRIPTION
This allows to see which rules are not present (speficially for 80-net-name-rules, which is not present at all).