### PR TITLE
chore: rekres to simplify `.kres.yaml` defaults

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,7 +16,7 @@
                 "Pkgfile"
             ],
             "matchStrings": [
-                "# renovate: datasource=(?<datasource>.*?)(?:\\s+extractVersion=(?<extractVersion>.+?))?(?:\\s+versioning=(?<versioning>.+?))?\\s+depName=(?<depName>.+?)?\\s(?:\\s+.*_(?:version|VERSION):\\s+(?<currentValue>.*))?(?:\\s.*_(?:ref|REF):\\s+(?<currentDigest>.*))?"
+                "# renovate: datasource=(?<datasource>.*?)(?:\\s+extractVersion=(?<extractVersion>.+?))?(?:\\s+versioning=(?<versioning>.+?))?\\s+depName=(?<depName>.+?)?\\s(?:.*_(?:version|VERSION):\\s+(?<currentValue>.*))?(?:(\\s)?.*_(?:ref|REF):\\s+(?<currentDigest>.*))?"
             ]
         },
         {
@@ -25,8 +25,7 @@
             "depNameTemplate": "siderolabs/bldr",
             "versioningTemplate": "semver",
             "fileMatch": [
-                "Pkgfile",
-                "Makefile"
+                "Pkgfile"
             ],
             "matchStrings": [
                 "ghcr.io\\/siderolabs\\/bldr:(?<currentValue>v.*)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-12-18T08:06:55Z by kres b9507d6.
+# Generated on 2024-12-18T18:38:18Z by kres fcff05e.
 
 name: default
 concurrency:
@@ -33,7 +33,7 @@ jobs:
       labels: ${{ steps.retrieve-pr-labels.outputs.result }}
     services:
       buildkitd:
-        image: moby/buildkit:v0.18.1
+        image: moby/buildkit:v0.18.2
         options: --privileged
         ports:
           - 1234:1234
@@ -137,7 +137,7 @@ jobs:
       - default
     services:
       buildkitd:
-        image: moby/buildkit:v0.18.1
+        image: moby/buildkit:v0.18.2
         options: --privileged
         ports:
           - 1234:1234

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-12-18T08:06:55Z by kres b9507d6.
+# Generated on 2024-12-18T18:38:18Z by kres fcff05e.
 
 name: weekly
 concurrency:
@@ -16,7 +16,7 @@ jobs:
       - pkgs
     services:
       buildkitd:
-        image: moby/buildkit:v0.18.1
+        image: moby/buildkit:v0.18.2
         options: --privileged
         ports:
           - 1234:1234

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -89,22 +89,6 @@ spec:
 ---
 kind: common.Renovate
 spec:
-  customManagers:
-    - customType: regex
-      fileMatch:
-        - Pkgfile
-      matchStrings:
-        - '# renovate: datasource=(?<datasource>.*?)(?:\s+extractVersion=(?<extractVersion>.+?))?(?:\s+versioning=(?<versioning>.+?))?\s+depName=(?<depName>.+?)?\s(?:\s+.*_(?:version|VERSION):\s+(?<currentValue>.*))?(?:\s.*_(?:ref|REF):\s+(?<currentDigest>.*))?'
-      versioningTemplate: "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"
-    - customType: regex
-      fileMatch:
-        - Pkgfile
-        - Makefile
-      matchStrings:
-        - ghcr.io\/siderolabs\/bldr:(?<currentValue>v.*)
-      depNameTemplate: siderolabs/bldr
-      datasourceTemplate: github-tags
-      versioningTemplate: semver
   packageRules:
     - matchPackageNames:
         - git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git


### PR DESCRIPTION
rekres to simplify `.kres.yaml` defaults.