### PR TITLE
chore: drop unused cert copy

### DIFF
--- a/kernel/kernel/pkg.yaml
+++ b/kernel/kernel/pkg.yaml
@@ -13,7 +13,7 @@ steps:
         mkdir -p /rootfs/boot
         mkdir -p /rootfs/dtb
         mkdir -p /rootfs/certs
-        cp /src/certs/signing_key.x509 /rootfs/certs/signing_key.x509
+
         case $ARCH in
             x86_64)
                 mv arch/x86/boot/bzImage /rootfs/boot/vmlinuz


### PR DESCRIPTION
Drop unused kernel signing public key copy. This was used when the integration tests used a `module-sig-verify`, now we verify certs in extension integration tests by actually loading them.