### PR TITLE
fix: build CNI plugins statically linked

### DIFF
--- a/cni/pkg.yaml
+++ b/cni/pkg.yaml
@@ -19,7 +19,7 @@ steps:
       - |
         export PATH=${PATH}:${TOOLCHAIN}/go/bin
         cd ${GOPATH}/src/
-        GOFLAGS="-ldflags=-s" /toolchain/bin/bash ./build_linux.sh
+        CGO_ENABLED=0 GOFLAGS="-ldflags=-s" /toolchain/bin/bash ./build_linux.sh
     install:
       - |
         mkdir -p /rootfs/opt/cni/bin


### PR DESCRIPTION
They are used e.g. by `talosctl` when they run on the host which can be not musl-based.