### PR TITLE
chore: support vmdk and cp format for qemu-img

### DIFF
--- a/libisofs/pkg.yaml
+++ b/libisofs/pkg.yaml
@@ -3,7 +3,6 @@ variant: scratch
 shell: /bin/bash
 dependencies:
   - stage: base
-  - stage: libburn
 steps:
   - sources:
       - url: https://files.libburnia-project.org/releases/libisofs-{{ .libisofs_version }}.tar.gz

--- a/pigz/pkg.yaml
+++ b/pigz/pkg.yaml
@@ -3,7 +3,6 @@ variant: scratch
 shell: /bin/bash
 dependencies:
   - stage: base
-  - stage: libburn
 steps:
   - sources:
       - url: https://zlib.net/pigz/pigz-{{ .pigz_version }}.tar.gz

--- a/qemu-tools/pkg.yaml
+++ b/qemu-tools/pkg.yaml
@@ -24,7 +24,9 @@ steps:
           --disable-docs \
           --disable-install-blobs \
           --enable-stack-protector \
-          --enable-tools
+          --enable-tools \
+          --enable-vmdk \
+          --enable-vpc
     build:
       - |
         make -j $(nproc)


### PR DESCRIPTION
Support `vmdk` and `vpc` format for `qemu-img` to be used for imager.