### PR TITLE
feat(kernel): add -@ to dtc flags for arm64 to enable overlay support

### DIFF
--- a/kernel/build/pkg.yaml
+++ b/kernel/build/pkg.yaml
@@ -36,7 +36,7 @@ steps:
 
         if [[ "${ARCH}" == "arm64" ]]; then
           echo "Compiling device-tree blobs"
-          make -j $(nproc) dtbs
+          make -j $(nproc) DTC_FLAGS=-@ dtbs
         fi
       {{ end }}
 finalize:


### PR DESCRIPTION
### Description

This change adds the `-@` flag to the Device Tree Compiler (DTC) flags during the compilation of Device Tree Blobs (DTBs) for the arm64 architecture, enabling proper support for device tree overlays.

**Motivation**

Device tree overlays require the base DTB to include a `/__symbols__` node, which contains the addresses of symbols.  This node is only generated when DTC is invoked with the `-@` flag.  Without this flag, applying overlays results in the following error:

> failed on fdt_overlay_apply(): FDT_ERR_BADMAGIC
> base fdt does not have a /\_\_symbols\_\_ node
> make sure you've compiled with -@

This change is a requirement for enabling device tree overlay support in the [sbc-rockchip](https://github.com/siderolabs/sbc-rockchip), where I am currently integrating this functionality.

**Changes**

*   Modified `kernel/build/pkg.yaml` to include `-@` in `DTC_FLAGS` for arm64 DTB compilation.

**Testing**

*   Verified successful DTB compilation.
*   Confirmed that device tree overlays can now be applied successfully on target arm64 platforms.