### PR TITLE
feat(containerd): provide ctr as part of the default containerd Talos build

### DIFF
--- a/containerd/pkg.yaml
+++ b/containerd/pkg.yaml
@@ -28,7 +28,7 @@ steps:
         mkdir -p /rootfs/usr/bin
         make install PREFIX=/usr DESTDIR=/rootfs
 
-        rm /rootfs/usr/bin/{containerd-stress,ctr}
+        rm /rootfs/usr/bin/containerd-stress
     test:
       - |
         fhs-validator /rootfs


### PR DESCRIPTION
This PR enables the Talos containerd package build to provide ctr as part of the Talos releases. ctr is often used for:

- Allows for easy debugging and troubleshooting container issues at the runtime level
- Provides visibility into certain container events as well as container data

Providing ctr as part of the builds in this repo ensures that the ctr version easily lines up with the released containerd version as well as makes it easier for testing, support, and certification with the Talos builds. Alternatively, it might be preferred to have ctr delivered as an extension instead. So, I will open a PR in the extensions repo in case a ctr extension is preferred instead of providing ctr by default as part of the Talos pkg builds.

