### PR TITLE
feat: update containerd 2.0.4, runc 1.2.6

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -13,10 +13,10 @@ vars:
   cni_sha512: ee577e3fe39558d6a6296754c97de6608f95152805c01b8053e2958d16634ab57d147eea7c950fcc4d1a98d6733a85717adf7078ee2dffff007ec3b063386c24
 
   # renovate: datasource=github-tags depName=containerd/containerd
-  containerd_version: v2.0.3
-  containerd_ref: 06b99ca80cdbfbc6cc8bd567021738c9af2b36ce
-  containerd_sha256: e2254cefb3818f7cdcf01fd5e4413b6c011c99504f8c880dda0a6fc8213c0332
-  containerd_sha512: 9528a65d9d9f13d15d861f7ce71ab483958020bda83947d18868b477204e9e2e33eccc69280502c54b2be9ce577724e3e2b1772229c99636099b04bac1079ac1
+  containerd_version: v2.0.4
+  containerd_ref: 1a43cb6a1035441f9aca8f5666a9b3ef9e70ab20
+  containerd_sha256: af0b18d125abf97fbe90d6d2cda53ffa0cd4cbb9e7d65fee61fc095bfb63cef5
+  containerd_sha512: f84e0cc0b82313df010b95989faf56e81ebfbbc321585b968c8c706917b91a9f0d895692fa5046f24f1c370de7a74b50daf83da617fe0595e5a8ff69ed658727
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/cryptsetup/cryptsetup.git
   cryptsetup_version: 2.7.5
@@ -201,10 +201,10 @@ vars:
   qemu_sha512: b010876da9f91da01dbb9e06705a1358d5f062d0fdd4ad5c8cd8ce3fd43adcefcf72a61216eb8d415281f6607b945ce1cfb6b5fc5692ada9163e8f05b7fb5533
 
   # renovate: datasource=github-tags depName=opencontainers/runc
-  runc_version: v1.2.5
-  runc_ref: 59923ef18c98053ddb1acf23ecba10344056c28e
-  runc_sha256: 700be41d0bf2be1ea8680fa77a801d307f1071062c6ecfed5874f6b803c5ef73
-  runc_sha512: b22ef70047cf98b3e633791b62b31002289c63d07c789c19709b8dbca1982756d862e1a962601722ea42cbcb8e1527d72ff4b0e71b588886d30e424f77eafd58
+  runc_version: v1.2.6
+  runc_ref: e89a29929c775025419ab0d218a43588b4c12b9a
+  runc_sha256: 39695adb39b0284a4fc4b184d764772d886121bf30378f9614a3abfbdc5ff11a
+  runc_sha512: 772265769316e62d9f3d3e09eb48c6f7a1299bedede0a9472add430474b33758b5e723a33b5121411c20e15cd171e3133e80ab88b7a8c082327181be5507f65b
 
   # renovate: datasource=git-tags extractVersion=^tag-(?<version>.*)$ depName=git://repo.or.cz/socat.git
   socat_version: 1.8.0.3


### PR DESCRIPTION
See:

* https://github.com/containerd/containerd/releases/tag/v2.0.4
* https://github.com/opencontainers/runc/releases/tag/v1.2.6