### PR TITLE
fix: trim qemu-tools

### DIFF
--- a/qemu-tools/pkg.yaml
+++ b/qemu-tools/pkg.yaml
@@ -34,7 +34,8 @@ steps:
       - |
         make DESTDIR=/rootfs install
 
-        rm -rf /rootfs/usr/share
+        rm -r /rootfs/usr/{share,libexec}
+        rm -f /rootfs/usr/bin/{qemu-edid,qemu-io,qemu-nbd,qemu-pr-helper,qemu-storage-daemon,qemu-vmsr-helper}
     test:
       - |
         fhs-validator /rootfs


### PR DESCRIPTION
Now it contains only `qemu-img`.

I believe we don't need any other binary, and the removed binaries are quite big.

```
-rwxr-xr-x 0/0          461536 2019-06-02 01:34 usr/bin/qemu-edid
-rwxr-xr-x 0/0         1518544 2019-06-02 01:34 usr/bin/qemu-io
-rwxr-xr-x 0/0         1635792 2019-06-02 01:34 usr/bin/qemu-nbd
-rwxr-xr-x 0/0          706672 2019-06-02 01:34 usr/bin/qemu-pr-helper
-rwxr-xr-x 0/0         2456944 2019-06-02 01:34 usr/bin/qemu-storage-daemon
-rwxr-xr-x 0/0          694288 2019-06-02 01:34 usr/bin/qemu-vmsr-helper
-rwxr-xr-x 0/0           14440 2019-06-02 01:34 usr/libexec/gio-launch-desktop
-rwxr-xr-x 0/0          461472 2019-06-02 01:34 usr/libexec/qemu-bridge-helper
```