### PR TITLE
feat: Add Xilinx DMA drivers to Talos

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -62,6 +62,7 @@ spec:
     - gasket-driver-pkg
     - nvidia-open-gpu-kernel-modules-lts-pkg
     - nvidia-open-gpu-kernel-modules-production-pkg
+    - xdma-driver-pkg
     - zfs-pkg
   additionalTargets:
     nonfree:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-03-31T10:51:16Z by kres d903dae.
+# Generated on 2025-03-31T16:25:48Z by kres d903dae.
 
 # common variables
 
@@ -101,6 +101,7 @@ TARGETS += ena-pkg
 TARGETS += gasket-driver-pkg
 TARGETS += nvidia-open-gpu-kernel-modules-lts-pkg
 TARGETS += nvidia-open-gpu-kernel-modules-production-pkg
+TARGETS += xdma-driver-pkg
 TARGETS += zfs-pkg
 NONFREE_TARGETS = nonfree-kmod-nvidia-lts-pkg
 NONFREE_TARGETS += nonfree-kmod-nvidia-production-pkg

--- a/Pkgfile
+++ b/Pkgfile
@@ -216,6 +216,11 @@ vars:
   socat_sha256: a9f9eb6cfb9aa6b1b4b8fe260edbac3f2c743f294db1e362b932eb3feca37ba4
   socat_sha512: 600a3387e9756e0937d2db49de9066df03d9818e4042da6b72109d1b5688dd72352754773a19bd2558fe93ec6a8a73e80e7cf2602fd915960f66c403fd89beef
 
+  # renovate: datasource=git-refs versioning=git depName=https://github.com/Xilinx/dma_ip_drivers.git
+  xdma_driver_version: 03ac7f31e256c5604eeb970e98d343cf925ddb52
+  xdma_driver_sha256: 942f54aa2569572e3ffebc14b7d0dd73d49315b0d7b63c9cc4ed04232e32073e
+  xdma_driver_sha512: 0d3be501410baaa75b422b96ba86971fff4e3dd7b99301c61a89d7523cda87cbcbe126f71c477f6f1938496d360e5d59e852c2ecdcfd8181d2fe6991d4596e9e
+
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git
   xfsprogs_version: 6.12.0
   xfsprogs_sha256: 0832407247db791cc70def96e7e254bd6edf043dc84a80a62f3ccd6e3dffd329

--- a/xdma-driver/pkg.yaml
+++ b/xdma-driver/pkg.yaml
@@ -1,0 +1,40 @@
+name: xdma-driver-pkg
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+  - stage: kernel-build
+steps:
+  - sources:
+      - url: https://github.com/Xilinx/dma_ip_drivers/archive/{{ .xdma_driver_version }}.tar.gz
+        destination: xdma-driver.tar.gz
+        sha256: "{{ .xdma_driver_sha256 }}"
+        sha512: "{{ .xdma_driver_sha512 }}"
+    env:
+      ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
+    prepare:
+      - |
+        tar xf xdma-driver.tar.gz --strip-components=1
+    build:
+      - |
+        cd XDMA/linux-kernel/xdma
+        make all BUILDSYSTEM_DIR=/src
+    install:
+      - |
+        cd XDMA/linux-kernel/xdma
+
+        mkdir -p /rootfs/usr/lib/modules/$(cat /src/include/config/kernel.release)
+        cp /src/modules.order /rootfs/usr/lib/modules/$(cat /src/include/config/kernel.release)/
+        cp /src/modules.builtin /rootfs/usr/lib/modules/$(cat /src/include/config/kernel.release)/
+        cp /src/modules.builtin.modinfo /rootfs/usr/lib/modules/$(cat /src/include/config/kernel.release)/
+
+        make -C /src M=$(pwd) modules_install INSTALL_MOD_PATH=/rootfs/usr INSTALL_MOD_DIR=extras INSTALL_MOD_STRIP=1
+    test:
+      - |
+        # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping
+        find /rootfs/usr/lib/modules -name '*.ko' -exec grep -FL '~Module signature appended~' {} \+
+      - |
+        fhs-validator /rootfs
+finalize:
+  - from: /rootfs
+    to: /


### PR DESCRIPTION
It's all in the title really, however I've tested this significantly and haven't been able to get the modules to load successfully when upgrading using an installer created with the extension that corresponds to this work. 

```
 user: warning: [2025-03-21T17:06:41.370911596Z]: [talos] controller failed {"component": "controller-runtime", "controller": "runtime.KernelModuleSpecController", "error": "error loading module
 \"xdma\": module not found"}
 ```
 Even though the extension installs as expected and the filesystem contains the requisite modules:
 ```
 NODE            NAMESPACE   TYPE              ID   VERSION   NAME          VERSION
<redacted>   runtime     ExtensionStatus   0    1         xdma-driver   aefa9a1
``` 

[Companion pr to extensions](https://github.com/siderolabs/extensions/pull/653)