### PR TITLE
fix: build containerd with Go 1.23

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,9 +3,9 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_MUSL_IMAGE: ghcr.io/siderolabs/toolchain-musl:v1.10.0
+  TOOLCHAIN_MUSL_IMAGE: ghcr.io/siderolabs/toolchain-musl:v1.11.0-alpha.0
   TOOLS_PREFIX: ghcr.io/siderolabs/
-  TOOLS_REV: v1.10.0
+  TOOLS_REV: v1.11.0-alpha.0
 
   # renovate: datasource=github-releases depName=containernetworking/plugins
   cni_version: v1.6.2

--- a/containerd/pkg.yaml
+++ b/containerd/pkg.yaml
@@ -22,6 +22,10 @@ steps:
         patch -p1 < /pkg/patches/11741-not-set-sandbox-id-when-use-podsandbox-type.patch
     build:
       - |
+        # use Go 1.23 to build containerd, a temporary workaround for https://github.com/golang/go/issues/73577
+        ln -sf /go123/bin/go /usr/bin/go
+        ln -sf /go123/bin/gofmt /usr/bin/gofmt
+
         make VERSION={{ .containerd_version }} REVISION={{ .containerd_ref }}
     install:
       - |


### PR DESCRIPTION
Fixes https://github.com/siderolabs/talos/issues/10855