### PR TITLE
Adding in hailort pkg

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -61,6 +61,7 @@ spec:
     - drbd-pkg
     - ena-pkg
     - gasket-driver-pkg
+    - hailort-pkg
     - nvidia-open-gpu-kernel-modules-lts-pkg
     - nvidia-open-gpu-kernel-modules-production-pkg
     - xdma-driver-pkg

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ TARGETS += kernel
 TARGETS += drbd-pkg
 TARGETS += ena-pkg
 TARGETS += gasket-driver-pkg
+TARGETS += hailort-pkg
 TARGETS += nvidia-open-gpu-kernel-modules-lts-pkg
 TARGETS += nvidia-open-gpu-kernel-modules-production-pkg
 TARGETS += xdma-driver-pkg

--- a/Pkgfile
+++ b/Pkgfile
@@ -64,6 +64,11 @@ vars:
   grub_sha256: f3c97391f7c4eaa677a78e090c7e97e6dc47b16f655f04683ebd37bef7fe0faa
   grub_sha512: 761c060a4c3da9c0e810b0ea967e3ebc66baa4ddd682a503ae3d30a83707626bccaf49359304a16b3a26fc4435fe6bea1ee90be910c84de3c2b5485a31a15be3
 
+  # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=hailo-ai/hailort-drivers
+  hailort_version: 4.21.0
+  hailort_sha256: 624468126c1e5609475389271b3d2878cb6e7e40df9e85bad95be464a3e11be3
+  hailort_sha512: 857f56f1788a05a666051c232bdfe4ad01bc22587cc83ef1e14079a71ab0083aefa98253d40999880c3570b774baf7ac585ccd7618ba7f28a056b7bc07c1701c
+
   # renovate: datasource=github-releases extractVersion=^IPMITOOL_(?<version>.*)$ depName=ipmitool/ipmitool
   ipmitool_version: 1_8_19
   ipmitool_sha256: 48b010e7bcdf93e4e4b6e43c53c7f60aa6873d574cbd45a8d86fa7aaeebaff9c

--- a/hailort/pkg.yaml
+++ b/hailort/pkg.yaml
@@ -1,0 +1,38 @@
+name: hailort-pkg
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+  - stage: kernel-build
+steps:
+  - sources:
+      - url: https://github.com/hailo-ai/hailort-drivers/archive/refs/tags/v{{ .hailort_version }}.tar.gz
+        destination: hailort-driver.tar.gz
+        sha256: "{{ .hailort_sha256 }}"
+        sha512: "{{ .hailort_sha512 }}"
+    env:
+      ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
+    prepare:
+      - |
+        tar xf hailort-driver.tar.gz --strip-components=1
+      - |
+        mkdir -p /rootfs/usr/lib/modules/$(cat /src/include/config/kernel.release) /rootfs/etc/udev/rules.d/
+    build:
+      - |
+        cd linux/pcie
+        make -j $(nproc) KERNEL_DIR=/src/ all
+    install:
+      - |
+        cp /src/modules.order /rootfs/usr/lib/modules/$(cat /src/include/config/kernel.release)/
+        cp /src/modules.builtin /rootfs/usr/lib/modules/$(cat /src/include/config/kernel.release)/
+        cp /src/modules.builtin.modinfo /rootfs/usr/lib/modules/$(cat /src/include/config/kernel.release)/
+
+        cd linux/pcie
+        make -j $(nproc) -C /src M=$(pwd) modules_install INSTALL_MOD_PATH=/rootfs/usr INSTALL_MOD_DIR=kernel/drivers/misc INSTALL_MOD_STRIP=1
+        cp 51-hailo-udev.rules /rootfs/etc/udev/rules.d/51-hailo-udev.rules
+    test:
+      - |
+        fhs-validator /rootfs
+finalize:
+  - from: /rootfs
+    to: /


### PR DESCRIPTION
Adding in support for https://github.com/hailo-ai/hailort-drivers for the Hailo suite of PCIe M.2 NPU devices.

Specifically I'm using the Hailo-8L that comes with the raspberry pi's AI hat.