### PR TITLE
fix: bring back updated containerd gvisor patch

### DIFF
--- a/containerd/patches/11741-not-set-sandbox-id-when-use-podsandbox-type.patch
+++ b/containerd/patches/11741-not-set-sandbox-id-when-use-podsandbox-type.patch
@@ -1,0 +1,65 @@
+From e9804ee0e9d85788648b589c17e67a024a93151e Mon Sep 17 00:00:00 2001
+From: yylt <yang8518296@163.com>
+Date: Tue, 22 Apr 2025 11:05:54 +0800
+Subject: [PATCH] not set sandbox id when use podsandbox type
+
+Signed-off-by: yang yang <yang8518296@163.com>
+(cherry picked from commit 4b4e6f7c693e3739deed20ed5832ede137b41b3e)
+Signed-off-by: Samuel Karp <samuelkarp@google.com>
+---
+ internal/cri/server/container_create.go            | 5 ++++-
+ internal/cri/server/podsandbox/controller.go       | 2 +-
+ internal/cri/server/podsandbox/types/podsandbox.go | 4 ++++
+ 3 files changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/internal/cri/server/container_create.go b/internal/cri/server/container_create.go
+index f27a92e88f37..09ce17749947 100644
+--- a/internal/cri/server/container_create.go
++++ b/internal/cri/server/container_create.go
+@@ -41,6 +41,7 @@ import (
+ 	cio "github.com/containerd/containerd/v2/internal/cri/io"
+ 	crilabels "github.com/containerd/containerd/v2/internal/cri/labels"
+ 	customopts "github.com/containerd/containerd/v2/internal/cri/opts"
++	podsandboxtypes "github.com/containerd/containerd/v2/internal/cri/server/podsandbox/types"
+ 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
+ 	"github.com/containerd/containerd/v2/internal/cri/util"
+ 	"github.com/containerd/containerd/v2/pkg/blockio"
+@@ -412,7 +413,9 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
+ 		containerd.WithContainerExtension(crilabels.ContainerMetadataExtension, r.meta),
+ 	)
+ 
+-	opts = append(opts, containerd.WithSandbox(r.sandboxID))
++	if r.sandbox.Sandboxer != podsandboxtypes.InternalSandboxID {
++		opts = append(opts, containerd.WithSandbox(r.sandboxID))
++	}
+ 
+ 	opts = append(opts, c.nri.WithContainerAdjustment())
+ 	defer func() {
+diff --git a/internal/cri/server/podsandbox/controller.go b/internal/cri/server/podsandbox/controller.go
+index a185a4ce8808..68e7203548e5 100644
+--- a/internal/cri/server/podsandbox/controller.go
++++ b/internal/cri/server/podsandbox/controller.go
+@@ -47,7 +47,7 @@ import (
+ func init() {
+ 	registry.Register(&plugin.Registration{
+ 		Type: plugins.PodSandboxPlugin,
+-		ID:   "podsandbox",
++		ID:   types.InternalSandboxID,
+ 		Requires: []plugin.Type{
+ 			plugins.EventPlugin,
+ 			plugins.LeasePlugin,
+diff --git a/internal/cri/server/podsandbox/types/podsandbox.go b/internal/cri/server/podsandbox/types/podsandbox.go
+index bbc83db1c876..362067f4929d 100644
+--- a/internal/cri/server/podsandbox/types/podsandbox.go
++++ b/internal/cri/server/podsandbox/types/podsandbox.go
+@@ -26,6 +26,10 @@ import (
+ 	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
+ )
+ 
++const (
++	InternalSandboxID = "podsandbox"
++)
++
+ type PodSandbox struct {
+ 	ID        string
+ 	Container containerd.Container

--- a/containerd/pkg.yaml
+++ b/containerd/pkg.yaml
@@ -19,6 +19,7 @@ steps:
         tar -xzf containerd.tar.gz --strip-components=1
       - |
         patch -p1 < /pkg/patches/restart.patch
+        patch -p1 < /pkg/patches/11741-not-set-sandbox-id-when-use-podsandbox-type.patch
     build:
       - |
         make VERSION={{ .containerd_version }} REVISION={{ .containerd_ref }} STATIC=1


### PR DESCRIPTION
When updating for containerd 2.1, I assumed the patch is no longer needed, as it was included into containerd, but it turns out it got reverted upstream: https://github.com/containerd/containerd/pull/11793

So bring back the patch in updated form, as otherwise `gvisor` leaves running processes behind on container stop.