### PR TITLE
chore: drop qemu-tools vmdk support

### DIFF
--- a/qemu-tools/pkg.yaml
+++ b/qemu-tools/pkg.yaml
@@ -25,7 +25,6 @@ steps:
           --disable-install-blobs \
           --enable-stack-protector \
           --enable-tools \
-          --enable-vmdk \
           --enable-vpc
     build:
       - |


### PR DESCRIPTION
With #1236 qemu-tools doesn't need vmdk support anymore.