### PR TITLE
fix: clean up some binaries

### DIFF
--- a/iptables/pkg.yaml
+++ b/iptables/pkg.yaml
@@ -33,6 +33,9 @@ steps:
       - |
         make install DESTDIR=/rootfs
       - |
+        # remove all shell scripts
+        find /rootfs/usr/bin -type f -perm /111 -exec grep -slIE '^#!' {} + | tee /dev/stderr | xargs rm
+      - |
         # fix up symlinks which point to legacy version to point to nft version
         for f in /rootfs/usr/bin/*; do
           # if name doesn't contain 'legacy':

--- a/libattr/pkg.yaml
+++ b/libattr/pkg.yaml
@@ -38,6 +38,9 @@ steps:
         make install DESTDIR=/rootfs
 
         rm -rf /rootfs/share
+      - |
+        # remove all binaries
+        rm -r /rootfs/usr/bin
     test:
       - |
         fhs-validator /rootfs

--- a/libcap2/pkg.yaml
+++ b/libcap2/pkg.yaml
@@ -6,6 +6,10 @@ dependencies:
   - image: "{{ .TOOLS_PREFIX }}tools-libcap:{{ .TOOLS_REV }}"
     to: /rootfs
 steps:
+  - install:
+      - |
+        # remove all binaries
+        rm -r /rootfs/usr/bin
   - test:
       - |
         fhs-validator /rootfs

--- a/lvm2/pkg.yaml
+++ b/lvm2/pkg.yaml
@@ -56,6 +56,9 @@ steps:
         rm -r /rootfs/usr/share
         # LVM activation is handled by Talos itself
         rm -f /rootfs/usr/lib/udev/rules.d/69-dm-lvm.rules
+      - |
+        # remove all shell scripts
+        find /rootfs/usr/bin -type f -perm /111 -exec grep -slIE '^#!' {} + | tee /dev/stderr | xargs rm
     test:
       - |
         fhs-validator /rootfs

--- a/openssl/pkg.yaml
+++ b/openssl/pkg.yaml
@@ -6,6 +6,10 @@ dependencies:
   - image: "{{ .TOOLS_PREFIX }}tools-openssl:{{ .TOOLS_REV }}"
     to: /rootfs
 steps:
+  - install:
+      - |
+        # remove all binaries
+        rm -r /rootfs/usr/bin
   - test:
       - |
         fhs-validator /rootfs

--- a/xfsprogs/pkg.yaml
+++ b/xfsprogs/pkg.yaml
@@ -33,6 +33,9 @@ steps:
         make install DESTDIR=/rootfs
         rm -rf /rootfs/usr/share/man
         rm -rf /rootfs/usr/share/doc
+      - |
+        # remove all shell scripts
+        find /rootfs/usr/bin -type f -perm /111 -exec grep -slIE '^#!' {} + | tee /dev/stderr | xargs rm
     test:
       - |
         fhs-validator /rootfs


### PR DESCRIPTION
Clean up binaries that either don't work on Talos (as they are shell scripts), or are not needed (e.g. `openssl`, `getcap`, etc.)

Fixes #1226