### PR TITLE
chore: remove unused udev programs

### DIFF
--- a/systemd-udevd/pkg.yaml
+++ b/systemd-udevd/pkg.yaml
@@ -31,6 +31,7 @@ steps:
         # Already built this
         rm -rf /rootfs/usr/lib/udev/hwdb.d
         rm /rootfs/usr/lib/udev/rules.d/{README,60-cdrom_id.rules,60-persistent-alsa.rules,60-persistent-v4l.rules,64-btrfs.rules,70-joystick.rules,70-mouse.rules,70-touchpad.rules,78-sound-card.rules,90-vconsole.rules,99-systemd.rules}
+        rm -f /rootfs/usr/lib/udev/{cdrom_id,v4l_id}
         # Azure csi support
         cp /pkg/files/66-azure.rules /rootfs/usr/lib/udev/rules.d/66-azure.rules
     test:


### PR DESCRIPTION
removes programs in /usr/lib/udev which are not called from udev rules.

Steps to reproduce findings
```
git clone https://github.com/siderolabs/talos 
cd talos
make initramfs
cd _out
zstd -d ./initramfs-amd64.xz
cpio -iv < initramfs-amd64
mkdir ./squashy
sudo mount --type squashfs --options loop --source ./rootfs.sqsh --target ./squashy
cd ./squashy/usr/lib/udev/rules.d
find .. -maxdepth 1 -mindepth 1 -type f -executable | sed 's,../,,g' | xargs -n1 sh -c 'grep -q -Rnw $PWD -e $1 || echo $1' sh
```