### PR TITLE
fix: download and copy hailo8 firmware as well

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -68,6 +68,8 @@ vars:
   hailort_version: 4.21.0
   hailort_sha256: 624468126c1e5609475389271b3d2878cb6e7e40df9e85bad95be464a3e11be3
   hailort_sha512: 857f56f1788a05a666051c232bdfe4ad01bc22587cc83ef1e14079a71ab0083aefa98253d40999880c3570b774baf7ac585ccd7618ba7f28a056b7bc07c1701c
+  hailort_fw_sha256: 2a5c94591d9e70d884242e64bf2388b0d2d46b816a335b4c00c3f81a07832635
+  hailort_fw_sha512: 43b36a7d958f4dba25f79ee37ad2ffa303c446a5c4516f7d882fb94c6ea0bee72089305b061a55b8bc37fc327ffce9db08f1f171a92c2421dd1a52a7c1695267
 
   # renovate: datasource=github-releases extractVersion=^IPMITOOL_(?<version>.*)$ depName=ipmitool/ipmitool
   ipmitool_version: 1_8_19

--- a/hailort/pkg.yaml
+++ b/hailort/pkg.yaml
@@ -10,22 +10,28 @@ steps:
         destination: hailort-driver.tar.gz
         sha256: "{{ .hailort_sha256 }}"
         sha512: "{{ .hailort_sha512 }}"
+
+      - url: https://hailo-hailort.s3.eu-west-2.amazonaws.com/Hailo8/{{ .hailort_version }}/FW/hailo8_fw.{{ .hailort_version }}.bin
+        destination: hailo8_fw.bin
+        sha256: "{{ .hailort_fw_sha256 }}"
+        sha512: "{{ .hailort_fw_sha512 }}"
     env:
       ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
     prepare:
       - |
         tar xf hailort-driver.tar.gz --strip-components=1
       - |
-        mkdir -p /rootfs/usr/lib/modules/$(cat /src/include/config/kernel.release) /rootfs/etc/udev/rules.d/
+        mkdir -p /rootfs/usr/lib/modules/$(cat /src/include/config/kernel.release)/ /rootfs/usr/lib/firmware/hailo/ /rootfs/usr/lib/udev/rules.d/
     build:
       - |
         cd linux/pcie
         make -j $(nproc) KERNEL_DIR=/src/ all
     install:
       - |
+        mv hailo8_fw.bin /rootfs/usr/lib/firmware/hailo/hailo8_fw.bin
         cd linux/pcie
         make -j $(nproc) -C /src M=$(pwd) modules_install INSTALL_MOD_PATH=/rootfs/usr INSTALL_MOD_DIR=kernel/drivers/misc INSTALL_MOD_STRIP=1
-        cp 51-hailo-udev.rules /rootfs/etc/udev/rules.d/51-hailo-udev.rules
+        cp 51-hailo-udev.rules /rootfs/usr/lib/udev/rules.d/51-hailo-udev.rules
     test:
       - |
         # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping


### PR DESCRIPTION
Download and include the required hailo8 firmware binary as well.

Also minor fix to the udev path change from `/etc` => `/usr/lib`