### PR TITLE
fix: remove erroneous PURLs

### DIFF
--- a/cni/pkg.yaml
+++ b/cni/pkg.yaml
@@ -26,7 +26,6 @@ steps:
     sbom:
       outputPath: /rootfs/usr/share/spdx/cni.spdx.json
       version: {{ .cni_version }}
-      purl: pkg:golang/github.com/containernetworking/plugins@{{ .cni_version }}
       cpes:
         - cpe:2.3:a:containernetworking:plugins:{{ .cni_version }}:*:*:*:*:*:*:*
         - cpe:2.3:a:linuxfoundation:cni_network_plugins:{{ .cni_version }}:*:*:*:*:*:*:*

--- a/containerd/pkg.yaml
+++ b/containerd/pkg.yaml
@@ -34,7 +34,6 @@ steps:
     sbom:
       outputPath: /rootfs/usr/share/spdx/containerd.spdx.json
       version: {{ .containerd_version }}
-      purl: pkg:golang/github.com/containerd/containerd@{{ .containerd_version }}
       cpes:
         - cpe:2.3:a:containerd:containerd:{{ .containerd_version }}:*:*:*:*:*:*:*
         - cpe:2.3:a:linuxfoundation:containerd:{{ .containerd_version }}:*:*:*:*:*:*:*

--- a/flannel-cni/pkg.yaml
+++ b/flannel-cni/pkg.yaml
@@ -43,7 +43,6 @@ steps:
     sbom:
       outputPath: /rootfs/usr/share/spdx/flannel-cni.spdx.json
       version: {{ .flannel_cni_version }}
-      purl: pkg:golang/github.com/flannel-io/cni-plugin@{{ .flannel_cni_version }}
       cpes:
         - cpe:2.3:a:flannel-io:cni-plugin:{{ .flannel_cni_version }}:*:*:*:*:*:*:*
         - cpe:2.3:a:flannel_io:cni-plugin:{{ .flannel_cni_version }}:*:*:*:*:*:*:*

--- a/runc/pkg.yaml
+++ b/runc/pkg.yaml
@@ -39,7 +39,6 @@ steps:
     sbom:
       outputPath: /rootfs/usr/share/spdx/runc.spdx.json
       version: {{ .runc_version }}
-      purl: pkg:golang/github.com/opencontainers/runc@{{ .runc_version }}
       cpes:
         - cpe:2.3:a:opencontainers:runc:{{ .runc_version }}:*:*:*:*:*:*:*
         - cpe:2.3:a:linuxfoundation:runc:{{ .runc_version }}:*:*:*:*:*:*:*


### PR DESCRIPTION
Even though these packages are built using Go, they are not used as
Go modules here. Do not confuse vulnerability scanners which reject
findings based on the package type.

Signed-off-by: Dmitrii Sharshakov <dmitry.sharshakov@siderolabs.com>
