### PR TITLE
fix: backport CVE kernel patches to 6.12

### DIFF
--- a/kernel/build/patches/0001-CVE-2025-21751-backport-for-Talos-net-mlx5-HWS-chang.patch
+++ b/kernel/build/patches/0001-CVE-2025-21751-backport-for-Talos-net-mlx5-HWS-chang.patch
@@ -1,0 +1,95 @@
+From 6f6d47e19e3d440e9b57c5236959cb77bd9345d7 Mon Sep 17 00:00:00 2001
+From: Yevgeny Kliteynik <kliteyn@nvidia.com>
+Date: Thu, 2 Jan 2025 20:14:05 +0200
+Subject: [PATCH 1/2] [CVE-2025-21751 backport for Talos] net/mlx5: HWS, change
+ error flow on matcher disconnect
+
+[ Upstream commit 1ce840c7a659aa53a31ef49f0271b4fd0dc10296 ]
+
+Currently, when firmware failure occurs during matcher disconnect flow,
+the error flow of the function reconnects the matcher back and returns
+an error, which continues running the calling function and eventually
+frees the matcher that is being disconnected.
+This leads to a case where we have a freed matcher on the matchers list,
+which in turn leads to use-after-free and eventual crash.
+
+This patch fixes that by not trying to reconnect the matcher back when
+some FW command fails during disconnect.
+
+Note that we're dealing here with FW error. We can't overcome this
+problem. This might lead to bad steering state (e.g. wrong connection
+between matchers), and will also lead to resource leakage, as it is
+the case with any other error handling during resource destruction.
+
+However, the goal here is to allow the driver to continue and not crash
+the machine with use-after-free error.
+
+Signed-off-by: Yevgeny Kliteynik <kliteyn@nvidia.com>
+Signed-off-by: Itamar Gozlan <igozlan@nvidia.com>
+Reviewed-by: Mark Bloch <mbloch@nvidia.com>
+Signed-off-by: Tariq Toukan <tariqt@nvidia.com>
+Link: https://patch.msgid.link/20250102181415.1477316-7-tariqt@nvidia.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+---
+ .../mlx5/core/steering/hws/mlx5hws_matcher.c  | 24 +++++++------------
+ 1 file changed, 8 insertions(+), 16 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlx5/core/steering/hws/mlx5hws_matcher.c b/drivers/net/ethernet/mellanox/mlx5/core/steering/hws/mlx5hws_matcher.c
+index 61a1155d4b4f..ce541c60c5b4 100644
+--- a/drivers/net/ethernet/mellanox/mlx5/core/steering/hws/mlx5hws_matcher.c
++++ b/drivers/net/ethernet/mellanox/mlx5/core/steering/hws/mlx5hws_matcher.c
+@@ -165,14 +165,14 @@ static int hws_matcher_disconnect(struct mlx5hws_matcher *matcher)
+ 						    next->match_ste.rtc_0_id,
+ 						    next->match_ste.rtc_1_id);
+ 		if (ret) {
+-			mlx5hws_err(tbl->ctx, "Failed to disconnect matcher\n");
+-			goto matcher_reconnect;
++			mlx5hws_err(tbl->ctx, "Fatal error, failed to disconnect matcher\n");
++			return ret;
+ 		}
+ 	} else {
+ 		ret = mlx5hws_table_connect_to_miss_table(tbl, tbl->default_miss.miss_tbl);
+ 		if (ret) {
+-			mlx5hws_err(tbl->ctx, "Failed to disconnect last matcher\n");
+-			goto matcher_reconnect;
++			mlx5hws_err(tbl->ctx, "Fatal error, failed to disconnect last matcher\n");
++			return ret;
+ 		}
+ 	}
+ 
+@@ -180,27 +180,19 @@ static int hws_matcher_disconnect(struct mlx5hws_matcher *matcher)
+ 	if (prev_ft_id == tbl->ft_id) {
+ 		ret = mlx5hws_table_update_connected_miss_tables(tbl);
+ 		if (ret) {
+-			mlx5hws_err(tbl->ctx, "Fatal error, failed to update connected miss table\n");
+-			goto matcher_reconnect;
++			mlx5hws_err(tbl->ctx,
++				    "Fatal error, failed to update connected miss table\n");
++			return ret;
+ 		}
+ 	}
+ 
+ 	ret = mlx5hws_table_ft_set_default_next_ft(tbl, prev_ft_id);
+ 	if (ret) {
+ 		mlx5hws_err(tbl->ctx, "Fatal error, failed to restore matcher ft default miss\n");
+-		goto matcher_reconnect;
++		return ret;
+ 	}
+ 
+ 	return 0;
+-
+-matcher_reconnect:
+-	if (list_empty(&tbl->matchers_list) || !prev)
+-		list_add(&matcher->list_node, &tbl->matchers_list);
+-	else
+-		/* insert after prev matcher */
+-		list_add(&matcher->list_node, &prev->list_node);
+-
+-	return ret;
+ }
+ 
+ static void hws_matcher_set_rtc_attr_sz(struct mlx5hws_matcher *matcher,
+-- 
+2.50.1
+

--- a/kernel/build/patches/0002-CVE-2025-37860-backport-for-Talos-sfc-fix-NULL-deref.patch
+++ b/kernel/build/patches/0002-CVE-2025-37860-backport-for-Talos-sfc-fix-NULL-deref.patch
@@ -1,0 +1,159 @@
+From ee23a2394ddf052539a366c1c8ae5a714d0c4230 Mon Sep 17 00:00:00 2001
+From: Edward Cree <ecree.xilinx@gmail.com>
+Date: Tue, 1 Apr 2025 23:54:39 +0100
+Subject: [PATCH 2/2] [CVE-2025-37860 backport for Talos] sfc: fix NULL
+ dereferences in ef100_process_design_param()
+
+[ Backporting to 6.12 required adding back MDIO device assignment ]
+
+[ Upstream commit 8241ecec1cdc6699ae197d52d58e76bddd995fa5 ]
+
+Since cited commit, ef100_probe_main() and hence also
+ ef100_check_design_params() run before efx->net_dev is created;
+ consequently, we cannot netif_set_tso_max_size() or _segs() at this
+ point.
+Move those netif calls to ef100_probe_netdev(), and also replace
+ netif_err within the design params code with pci_err.
+
+Reported-by: Kyungwook Boo <bookyungwook@gmail.com>
+Fixes: 98ff4c7c8ac7 ("sfc: Separate netdev probe/remove from PCI probe/remove")
+Signed-off-by: Edward Cree <ecree.xilinx@gmail.com>
+Reviewed-by: Michal Swiatkowski <michal.swiatkowski@linux.intel.com>
+Link: https://patch.msgid.link/20250401225439.2401047-1-edward.cree@amd.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+---
+ drivers/net/ethernet/sfc/ef100_netdev.c |  6 ++--
+ drivers/net/ethernet/sfc/ef100_nic.c    | 47 +++++++++++--------------
+ 2 files changed, 24 insertions(+), 29 deletions(-)
+
+diff --git a/drivers/net/ethernet/sfc/ef100_netdev.c b/drivers/net/ethernet/sfc/ef100_netdev.c
+index 7f7d560cb2b4..a8790148dfd8 100644
+--- a/drivers/net/ethernet/sfc/ef100_netdev.c
++++ b/drivers/net/ethernet/sfc/ef100_netdev.c
+@@ -450,9 +450,10 @@ int ef100_probe_netdev(struct efx_probe_data *probe_data)
+ 	net_dev->hw_enc_features |= efx->type->offload_features;
+ 	net_dev->vlan_features |= NETIF_F_HW_CSUM | NETIF_F_SG |
+ 				  NETIF_F_HIGHDMA | NETIF_F_ALL_TSO;
+-	netif_set_tso_max_segs(net_dev,
+-			       ESE_EF100_DP_GZ_TSO_MAX_HDR_NUM_SEGS_DEFAULT);
+ 	efx->mdio.dev = net_dev;
++	nic_data = efx->nic_data;
++	netif_set_tso_max_size(efx->net_dev, nic_data->tso_max_payload_len);
++	netif_set_tso_max_segs(efx->net_dev, nic_data->tso_max_payload_num_segs);
+ 
+ 	rc = efx_ef100_init_datapath_caps(efx);
+ 	if (rc < 0)
+@@ -478,7 +479,6 @@ int ef100_probe_netdev(struct efx_probe_data *probe_data)
+ 	/* Don't fail init if RSS setup doesn't work. */
+ 	efx_mcdi_push_default_indir_table(efx, efx->n_rx_channels);
+ 
+-	nic_data = efx->nic_data;
+ 	rc = ef100_get_mac_address(efx, net_dev->perm_addr, CLIENT_HANDLE_SELF,
+ 				   efx->type->is_vf);
+ 	if (rc)
+diff --git a/drivers/net/ethernet/sfc/ef100_nic.c b/drivers/net/ethernet/sfc/ef100_nic.c
+index 6da06931187d..5b1bdcac81d9 100644
+--- a/drivers/net/ethernet/sfc/ef100_nic.c
++++ b/drivers/net/ethernet/sfc/ef100_nic.c
+@@ -887,8 +887,7 @@ static int ef100_process_design_param(struct efx_nic *efx,
+ 	case ESE_EF100_DP_GZ_TSO_MAX_HDR_NUM_SEGS:
+ 		/* We always put HDR_NUM_SEGS=1 in our TSO descriptors */
+ 		if (!reader->value) {
+-			netif_err(efx, probe, efx->net_dev,
+-				  "TSO_MAX_HDR_NUM_SEGS < 1\n");
++			pci_err(efx->pci_dev, "TSO_MAX_HDR_NUM_SEGS < 1\n");
+ 			return -EOPNOTSUPP;
+ 		}
+ 		return 0;
+@@ -901,32 +900,28 @@ static int ef100_process_design_param(struct efx_nic *efx,
+ 		 */
+ 		if (!reader->value || reader->value > EFX_MIN_DMAQ_SIZE ||
+ 		    EFX_MIN_DMAQ_SIZE % (u32)reader->value) {
+-			netif_err(efx, probe, efx->net_dev,
+-				  "%s size granularity is %llu, can't guarantee safety\n",
+-				  reader->type == ESE_EF100_DP_GZ_RXQ_SIZE_GRANULARITY ? "RXQ" : "TXQ",
+-				  reader->value);
++			pci_err(efx->pci_dev,
++				"%s size granularity is %llu, can't guarantee safety\n",
++				reader->type == ESE_EF100_DP_GZ_RXQ_SIZE_GRANULARITY ? "RXQ" : "TXQ",
++				reader->value);
+ 			return -EOPNOTSUPP;
+ 		}
+ 		return 0;
+ 	case ESE_EF100_DP_GZ_TSO_MAX_PAYLOAD_LEN:
+ 		nic_data->tso_max_payload_len = min_t(u64, reader->value,
+ 						      GSO_LEGACY_MAX_SIZE);
+-		netif_set_tso_max_size(efx->net_dev,
+-				       nic_data->tso_max_payload_len);
+ 		return 0;
+ 	case ESE_EF100_DP_GZ_TSO_MAX_PAYLOAD_NUM_SEGS:
+ 		nic_data->tso_max_payload_num_segs = min_t(u64, reader->value, 0xffff);
+-		netif_set_tso_max_segs(efx->net_dev,
+-				       nic_data->tso_max_payload_num_segs);
+ 		return 0;
+ 	case ESE_EF100_DP_GZ_TSO_MAX_NUM_FRAMES:
+ 		nic_data->tso_max_frames = min_t(u64, reader->value, 0xffff);
+ 		return 0;
+ 	case ESE_EF100_DP_GZ_COMPAT:
+ 		if (reader->value) {
+-			netif_err(efx, probe, efx->net_dev,
+-				  "DP_COMPAT has unknown bits %#llx, driver not compatible with this hw\n",
+-				  reader->value);
++			pci_err(efx->pci_dev,
++				"DP_COMPAT has unknown bits %#llx, driver not compatible with this hw\n",
++				reader->value);
+ 			return -EOPNOTSUPP;
+ 		}
+ 		return 0;
+@@ -946,10 +941,10 @@ static int ef100_process_design_param(struct efx_nic *efx,
+ 		 * So the value of this shouldn't matter.
+ 		 */
+ 		if (reader->value != ESE_EF100_DP_GZ_VI_STRIDES_DEFAULT)
+-			netif_dbg(efx, probe, efx->net_dev,
+-				  "NIC has other than default VI_STRIDES (mask "
+-				  "%#llx), early probing might use wrong one\n",
+-				  reader->value);
++			pci_dbg(efx->pci_dev,
++				"NIC has other than default VI_STRIDES (mask "
++				"%#llx), early probing might use wrong one\n",
++				reader->value);
+ 		return 0;
+ 	case ESE_EF100_DP_GZ_RX_MAX_RUNT:
+ 		/* Driver doesn't look at L2_STATUS:LEN_ERR bit, so we don't
+@@ -961,9 +956,9 @@ static int ef100_process_design_param(struct efx_nic *efx,
+ 		/* Host interface says "Drivers should ignore design parameters
+ 		 * that they do not recognise."
+ 		 */
+-		netif_dbg(efx, probe, efx->net_dev,
+-			  "Ignoring unrecognised design parameter %u\n",
+-			  reader->type);
++		pci_dbg(efx->pci_dev,
++			"Ignoring unrecognised design parameter %u\n",
++			reader->type);
+ 		return 0;
+ 	}
+ }
+@@ -999,13 +994,13 @@ static int ef100_check_design_params(struct efx_nic *efx)
+ 	 */
+ 	if (reader.state != EF100_TLV_TYPE) {
+ 		if (reader.state == EF100_TLV_TYPE_CONT)
+-			netif_err(efx, probe, efx->net_dev,
+-				  "truncated design parameter (incomplete type %u)\n",
+-				  reader.type);
++			pci_err(efx->pci_dev,
++				"truncated design parameter (incomplete type %u)\n",
++				reader.type);
+ 		else
+-			netif_err(efx, probe, efx->net_dev,
+-				  "truncated design parameter %u\n",
+-				  reader.type);
++			pci_err(efx->pci_dev,
++				"truncated design parameter %u\n",
++				reader.type);
+ 		rc = -EIO;
+ 	}
+ out:
+-- 
+2.50.1
+

--- a/kernel/build/patches/README.md
+++ b/kernel/build/patches/README.md
@@ -1,3 +1,5 @@
 | Patch file                                                                 | Description                                | Upstream status | Link                                                                                                                                                                                                         |
 |----------------------------------------------------------------------------|--------------------------------------------|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | mglru.patch | Backport fixes for OOM in memory-constrained cgroups on fast IO | in 6.13 | Commit 1bc542c6a0d1444559ab75823a89a94d244bf933 |
+| 0001-CVE-2025-21751-backport-for-Talos-net-mlx5-HWS-chang.patch | Backport CVE-2025-21751 patch | Commit 1ce840c7a659aa53a31ef49f0271b4fd0dc10296 |
+| 0002-CVE-2025-37860-backport-for-Talos-sfc-fix-NULL-deref.patch | Backport CVE-2025-37860 patch | Commit 8241ecec1cdc6699ae197d52d58e76bddd995fa5 |


### PR DESCRIPTION
CVEs:

* CVE-2025-21751
* CVE-2025-37860

The actual patches are done by @dsseng.

See https://github.com/siderolabs/talos/issues/11416