### PR TITLE
Enable Kernel config options for IPVS Maglev hashing scheduler support

### DIFF
--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1604,7 +1604,7 @@ CONFIG_IP_VS_LC=y
 # CONFIG_IP_VS_LBLCR is not set
 # CONFIG_IP_VS_DH is not set
 CONFIG_IP_VS_SH=y
-# CONFIG_IP_VS_MH is not set
+CONFIG_IP_VS_MH=y
 # CONFIG_IP_VS_SED is not set
 # CONFIG_IP_VS_NQ is not set
 # CONFIG_IP_VS_TWOS is not set

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1582,7 +1582,7 @@ CONFIG_IP_VS_LC=y
 # CONFIG_IP_VS_LBLCR is not set
 # CONFIG_IP_VS_DH is not set
 CONFIG_IP_VS_SH=y
-# CONFIG_IP_VS_MH is not set
+CONFIG_IP_VS_MH=y
 # CONFIG_IP_VS_SED is not set
 # CONFIG_IP_VS_NQ is not set
 # CONFIG_IP_VS_TWOS is not set


### PR DESCRIPTION
Adds support for the IPVS scheduler that uses maglev hashing. Fixes https://github.com/siderolabs/pkgs/issues/1326.