### PR TITLE
fix: build nftables with embedded gmp

### DIFF
--- a/nftables/pkg.yaml
+++ b/nftables/pkg.yaml
@@ -21,7 +21,8 @@ steps:
           --prefix=/usr \
           --disable-man-doc \
           --sbindir=/usr/bin \
-          --without-cli
+          --without-cli \
+          --with-mini-gmp=yes
     build:
       - |
         make -j $(nproc)


### PR DESCRIPTION
Otherwise it links with libgmp, which we don't ship in Talos rootfs.