### PR TITLE
chore: update linuxfirmware and rekres

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -1,9 +1,9 @@
-# syntax = ghcr.io/siderolabs/bldr:v0.5.3
+# syntax = ghcr.io/siderolabs/bldr:v0.5.4
 
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_MUSL_IMAGE: ghcr.io/siderolabs/toolchain-musl:v1.12.0-alpha.0-4-g00e3d96
+  TOOLCHAIN_MUSL_IMAGE: ghcr.io/siderolabs/toolchain-musl:v1.12.0-alpha.0-6-gfd8b77d
   TOOLS_PREFIX: ghcr.io/siderolabs/
   TOOLS_REV: v1.12.0-alpha.0-6-gc37ac80
 
@@ -169,9 +169,9 @@ vars:
   liburcu_sha512: 164d369cc1375b6b71eaa26812aff8a294bfbdffde65c2668e5c559d215d74c1973681f8083bfde39e280ca6fe8e92aadc7c867f966a5769548b754c92389616
 
   # renovate: datasource=git-tags depName=git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
-  linux_firmware_version: 20250808
-  linux_firmware_sha256: 7154b0ece5d98b0756e605465ad5ee6d1aff87e26d802da9c85429eb893408e9
-  linux_firmware_sha512: a7ad79f28bf7824bd978126400c98b479daa93cceb6bb052c7f9149f23641db108807d03f01c5cfafc4c10acda329a608ae59fd4676aa8eec8ba119d8749e223
+  linux_firmware_version: 20250917
+  linux_firmware_sha256: 5fd67b94e19b768e706608a6c8af5e4e95770245045a58a27157aa9a07df1e92
+  linux_firmware_sha512: b18c4ff2821c6b40fabbc8ae12fbcb75262bc56cd4cf8b65124e4faa1fefd4c15ccdc36d57467a6066402cf19b28a1690224797bebcf16cd367bf02f5df7e14f
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://sourceware.org/git/lvm2.git
   lvm2_version: 2_03_35


### PR DESCRIPTION
Run rekres, update linuxfirmware and
update all checksums.

| Package | Update | Change |
|---|---|---|
| git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git | minor | `20250808` -> `20250917` |
| | rekres | |
| [siderolabs/bldr](https://redirect.github.com/siderolabs/bldr) | patch | `v0.5.3` -> `v0.5.4` |

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
