### PR TITLE
feat: bump go

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,9 +3,9 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_MUSL_IMAGE: ghcr.io/siderolabs/toolchain-musl:v1.12.0-alpha.0-6-gfd8b77d
+  TOOLCHAIN_MUSL_IMAGE: ghcr.io/siderolabs/toolchain-musl:v1.12.0-alpha.0-9-g6da0776
   TOOLS_PREFIX: ghcr.io/siderolabs/
-  TOOLS_REV: v1.12.0-alpha.0-13-g11f0337
+  TOOLS_REV: v1.12.0-alpha.0-15-ge62d613
 
   # renovate: datasource=github-releases depName=containernetworking/plugins
   cni_version: v1.8.0


### PR DESCRIPTION
Bump Go to 1.25.3 via https://github.com/siderolabs/tools/pull/485