### PR TITLE
feat: add nvidia gdrcopy gdrdrv kernel module

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -263,5 +263,10 @@ vars:
   apparmor_version: v3.1.7 # v4 requires autoconf-archive
   apparmor_sha256: 64494bd99fa6547a9cbdb4fc6bc732451a02dd19e6eb70eab977b239632151eb
   apparmor_sha512: cfd6b0afb98d4559c16a6a2e23ca16ee9d86325fc6059313df5d3e8feba3d398f96a5754d3880dd2cafb2e7b1a06bd789d62cd36aaf993e46290f6311bb49dac
+
+  # renovate: datasource=github-tags depName=NVIDIA/gdrcopy
+  gdrcopy_version: v2.5.1
+  gdrcopy_sha256: c6d5ebb7dabb89d798f27609511735595004da73af28d93ac041bb5290c4cbec
+  gdrcopy_sha512: eb45965de6660bd33173cc150a373c185113e98aa66b8ead90871cf358c3423c3e5757438b841b38c8c2a993789dfc7f242a25e2e2b20f1dde2b592b646d2a30
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/pkgs

--- a/nvidia-open-gpu-kernel-modules/lts/pkg.yaml
+++ b/nvidia-open-gpu-kernel-modules/lts/pkg.yaml
@@ -17,19 +17,36 @@ steps:
         sha256: "{{ .nvidia_driver_lts_amd64_sha256 }}"
         sha512: "{{ .nvidia_driver_lts_amd64_sha512 }}"
     # {{ end }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
+      - url: https://github.com/NVIDIA/gdrcopy/archive/refs/tags/{{ .gdrcopy_version }}.tar.gz
+        destination: gdrcopy.tar.gz
+        sha256: "{{ .gdrcopy_sha256 }}"
+        sha512: "{{ .gdrcopy_sha512 }}"
     env:
       ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
     prepare:
       - |
-        tar xf nvidia.tar.xz --strip-components=1
+        mkdir -p /nvidia-driver
+        tar xf nvidia.tar.xz -C /nvidia-driver --strip-components=1
+      - |
+        mkdir -p /gdrcopy
+        tar xf gdrcopy.tar.gz -C /gdrcopy --strip-components=1
     build:
       - |
-        cd kernel-open
+        cd /nvidia-driver/kernel-open
 
         make -j $(nproc) SYSSRC=/src
+      - |
+        cd /gdrcopy/src/gdrdrv
+        # Build the kernel module with NVIDIA driver sources and kernel 6.12 compatibility flags
+        make -C /src M=/gdrcopy/src/gdrdrv modules \
+          NVIDIA_SRC_DIR=/nvidia-driver/kernel-open/nvidia \
+          NVIDIA_IS_OPENSOURCE=y \
+          HAVE_VM_FLAGS_SET=y \
+          HAVE_PROC_OPS=y \
+          KDIR=/src
     install:
       - |
-        cd kernel-open
+        cd /nvidia-driver/kernel-open
 
         mkdir -p /rootfs/usr/lib/modules/$(cat /src/include/config/kernel.release)/
         cp /src/modules.order /rootfs/usr/lib/modules/$(cat /src/include/config/kernel.release)/
@@ -37,6 +54,11 @@ steps:
         cp /src/modules.builtin.modinfo /rootfs/usr/lib/modules/$(cat /src/include/config/kernel.release)/
 
         make -j $(nproc) modules_install SYSSRC=/src INSTALL_MOD_PATH=/rootfs/usr INSTALL_MOD_STRIP=1
+      - |
+        cd /gdrcopy
+
+        # Install the gdrdrv kernel module
+        make -C /src M=/gdrcopy/src/gdrdrv modules_install INSTALL_MOD_PATH=/rootfs/usr INSTALL_MOD_DIR=extras INSTALL_MOD_STRIP=1
     test:
       - |
         # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping

--- a/nvidia-open-gpu-kernel-modules/production/pkg.yaml
+++ b/nvidia-open-gpu-kernel-modules/production/pkg.yaml
@@ -17,19 +17,36 @@ steps:
         sha256: "{{ .nvidia_driver_production_amd64_sha256 }}"
         sha512: "{{ .nvidia_driver_production_amd64_sha512 }}"
     # {{ end }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
+      - url: https://github.com/NVIDIA/gdrcopy/archive/refs/tags/{{ .gdrcopy_version }}.tar.gz
+        destination: gdrcopy.tar.gz
+        sha256: "{{ .gdrcopy_sha256 }}"
+        sha512: "{{ .gdrcopy_sha512 }}"
     env:
       ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
     prepare:
       - |
-        tar xf nvidia.tar.xz --strip-components=1
+        mkdir -p /nvidia-driver
+        tar xf nvidia.tar.xz -C /nvidia-driver --strip-components=1
+      - |
+        mkdir -p /gdrcopy
+        tar xf gdrcopy.tar.gz -C /gdrcopy --strip-components=1
     build:
       - |
-        cd kernel-open
+        cd /nvidia-driver/kernel-open
 
         make -j $(nproc) SYSSRC=/src
+      - |
+        cd /gdrcopy/src/gdrdrv
+        # Build the kernel module with NVIDIA driver sources and kernel 6.12 compatibility flags
+        make -C /src M=/gdrcopy/src/gdrdrv modules \
+          NVIDIA_SRC_DIR=/nvidia-driver/kernel-open/nvidia \
+          NVIDIA_IS_OPENSOURCE=y \
+          HAVE_VM_FLAGS_SET=y \
+          HAVE_PROC_OPS=y \
+          KDIR=/src
     install:
       - |
-        cd kernel-open
+        cd /nvidia-driver/kernel-open
 
         mkdir -p /rootfs/usr/lib/modules/$(cat /src/include/config/kernel.release)/
         cp /src/modules.order /rootfs/usr/lib/modules/$(cat /src/include/config/kernel.release)/
@@ -37,6 +54,11 @@ steps:
         cp /src/modules.builtin.modinfo /rootfs/usr/lib/modules/$(cat /src/include/config/kernel.release)/
 
         make -j $(nproc) modules_install SYSSRC=/src INSTALL_MOD_PATH=/rootfs/usr INSTALL_MOD_STRIP=1
+      - |
+        cd /gdrcopy
+
+        # Install the gdrdrv kernel module
+        make -C /src M=/gdrcopy/src/gdrdrv modules_install INSTALL_MOD_PATH=/rootfs/usr INSTALL_MOD_DIR=extras INSTALL_MOD_STRIP=1
     test:
       - |
         # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping


### PR DESCRIPTION
This adds the gdrdrv kernel module to enable low latency GPU memory copy based on GPUDirect RDMA.