### PR TITLE
backports: feat: update containerd to 2.1.5

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -13,10 +13,10 @@ vars:
   cni_sha512: 5b1a8c1a63f6f7a7ca4df570bf5c4b2003cdfe1b861ac86f145b5b523c9371275f68b01a115566a4f3455e56709a5a280b485005ea3fa121c1f381fbf6bd500e
 
   # renovate: datasource=github-tags depName=containerd/containerd
-  containerd_version: v2.1.4
-  containerd_ref: 75cb2b7193e4e490e9fbdc236c0e811ccaba3376
-  containerd_sha256: 8c409f8a0ba6015cb365a95e039a0fc9f3663c891a26eb52c0fb8cd291ba75d4
-  containerd_sha512: a9f84784e917621ee5ea38ad20b8106e642fbf463a00d319b73a1a8e4d1fdd5be2fba0789b6a5d31107ef239d3713eced99ce979d4b2764714271a63c0936c15
+  containerd_version: v2.1.5
+  containerd_ref: fcd43222d6b07379a4be9786bda52438f0dd16a1
+  containerd_sha256: f8def69e02ecff84c07e24350be0b834a3a8e1f6accf042cae4d504e52eb03d1
+  containerd_sha512: 6376228edf615b1ff3d40287622d4f72793be091d59d5d7e97f7bdc4f265aa4412f4a5dd1937ef795e54aa5ee8a87d785e859d7c6525a25fa86631b878cefc59
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/cryptsetup/cryptsetup.git
   cryptsetup_version: 2.8.0


### PR DESCRIPTION
See https://github.com/containerd/containerd/releases/tag/v2.1.5


(cherry picked from commit 0abcf011bd8b1d81345ada3f3feffad5c47ca131)