### PR TITLE
chore(makefile): fix help menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ NONFREE_TARGETS += nonfree-kmod-nvidia-production-pkg
 
 # help menu
 
-export define HELP_MENU_HEADER
+define HELP_MENU_HEADER
 # Getting Started
 
 To build this project, you must have the following installed:
@@ -239,4 +239,3 @@ release-notes: $(ARTIFACTS)
 conformance:
 	@docker pull $(CONFORMANCE_IMAGE)
 	@docker run --rm -it -v $(PWD):/src -w /src $(CONFORMANCE_IMAGE) enforce
-


### PR DESCRIPTION
UPDATE 2: `brew install make && gmake help` solves it.

UPDATE: I see that it should be "fixed" in https://github.com/siderolabs/kres

I'm not sure why it throws an error.

---

_Old topic:_

I'm trying to doing some testing for https://github.com/siderolabs/sbc-raspberrypi/issues/58#issuecomment-3553462375.  And I've started my journey to setup a development environment.  However, I came cross this:

```shell
$ make help
Makefile:122: *** missing separator.  Stop.
```

Comparing to https://github.com/siderolabs/talos/blob/main/Makefile, which worked (yet with some sed errors[0]).  I tracked it down to being an `export` too much.  Removing it fixes the output for me:

```shell
$ make help

all                            Builds all targets defined.
clean                          Cleans up all artifacts.
target-%                       Builds the specified target defined in the Pkgfile. The build result will only remain in the build cache.
local-%                        Builds the specified target defined in the Pkgfile using the local output type. The build result will be output to the specified local destination.
docker-%                       Builds the specified target defined in the Pkgfile using the docker output type. The build result will be loaded into Docker.
reproducibility-test           Builds the reproducibility test target
reproducibility-test-local-%   Builds the specified target defined in the Pkgfile using the local output type with and without cahce. The build result will be output to the specified local destination
update-checksums               Updates the checksums in the Pkgfile/vars.yaml based on the changed version variables.
nonfree                        Builds all nonfree targets defined.
help                           This help menu.
```

---

[0]: Error

This is the output I can from Talos help.  I'm on macOS.

```shell
$ make help
/bin/sh: -c: line 0: unexpected EOF while looking for matching `''
/bin/sh: -c: line 1: syntax error: unexpected end of file
...
```