### PR TITLE
feat: update containerd to v2.1.6

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -13,10 +13,10 @@ vars:
   cni_sha512: 8383a9f3fca75e978b84035609668f139e34cac7c5c1547c2913b6893754c3a0ec55acef73fd8e362094ca022359f2fa6c54dec55bada6b8fb8db7e9d7c889ea
 
   # renovate: datasource=github-tags depName=containerd/containerd
-  containerd_version: v2.1.5
-  containerd_ref: fcd43222d6b07379a4be9786bda52438f0dd16a1
-  containerd_sha256: f8def69e02ecff84c07e24350be0b834a3a8e1f6accf042cae4d504e52eb03d1
-  containerd_sha512: 6376228edf615b1ff3d40287622d4f72793be091d59d5d7e97f7bdc4f265aa4412f4a5dd1937ef795e54aa5ee8a87d785e859d7c6525a25fa86631b878cefc59
+  containerd_version: v2.1.6
+  containerd_ref: c74fd8780002eb26bd5940ae339d690d891221c2
+  containerd_sha256: 9b13537e5d61b9cf301295a807751447cc7c86fd79bb37ac5630455013d353a5
+  containerd_sha512: 63bc424a4f3ab56edab89bffe863551286eac224b516fe283ad132cd60e2c2a0d9c6e41fbc2076936ba5a70b467f17229587f8c38d855286f66477147a3490d2
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/cryptsetup/cryptsetup.git
   cryptsetup_version: 2.8.1

--- a/containerd/patches/cgroups.patch
+++ b/containerd/patches/cgroups.patch
@@ -1,15 +1,7 @@
 diff --git a/go.mod b/go.mod
-index 9010fd18a..667d98533 100644
+index 1e96a3d17..f74c5469b 100644
 --- a/go.mod
 +++ b/go.mod
-@@ -1,6 +1,6 @@
- module github.com/containerd/containerd/v2
- 
--go 1.23.0
-+go 1.24.0
- 
- require (
- 	dario.cat/mergo v1.0.1
 @@ -10,7 +10,7 @@ require (
  	github.com/checkpoint-restore/checkpointctl v1.3.0
  	github.com/checkpoint-restore/go-criu/v7 v7.2.0
@@ -26,7 +18,7 @@ index 9010fd18a..667d98533 100644
 -	github.com/containerd/nri v0.8.0
 +	github.com/containerd/nri v0.10.1-0.20251117084425-3827d9da021a
  	github.com/containerd/otelttrpc v0.1.0
- 	github.com/containerd/platforms v1.0.0-rc.1
+ 	github.com/containerd/platforms v1.0.0-rc.2
  	github.com/containerd/plugin v1.0.0
 @@ -52,8 +52,8 @@ require (
  	github.com/moby/sys/userns v0.1.0
@@ -36,7 +28,7 @@ index 9010fd18a..667d98533 100644
 -	github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626
 +	github.com/opencontainers/runtime-spec v1.3.0
 +	github.com/opencontainers/runtime-tools v0.9.1-0.20251114084447-edf4cb3d2116
- 	github.com/opencontainers/selinux v1.12.0
+ 	github.com/opencontainers/selinux v1.13.1
  	github.com/pelletier/go-toml/v2 v2.2.4
  	github.com/prometheus/client_golang v1.22.0
 @@ -85,7 +85,7 @@ require (
@@ -48,7 +40,7 @@ index 9010fd18a..667d98533 100644
  )
  
  require (
-@@ -110,10 +110,12 @@ require (
+@@ -111,10 +111,12 @@ require (
  	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0 // indirect
  	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.1 // indirect
  	github.com/json-iterator/go v1.1.12 // indirect
@@ -61,7 +53,7 @@ index 9010fd18a..667d98533 100644
  	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
  	github.com/modern-go/reflect2 v1.0.2 // indirect
  	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-@@ -128,7 +130,7 @@ require (
+@@ -129,7 +131,7 @@ require (
  	github.com/sasha-s/go-deadlock v0.3.5 // indirect
  	github.com/smallstep/pkcs7 v0.1.1 // indirect
  	github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6 // indirect
@@ -70,7 +62,7 @@ index 9010fd18a..667d98533 100644
  	github.com/x448/float16 v0.8.4 // indirect
  	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
  	go.opencensus.io v0.24.0 // indirect
-@@ -149,7 +151,7 @@ require (
+@@ -150,7 +152,7 @@ require (
  	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
  	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
  	sigs.k8s.io/yaml v1.4.0 // indirect
@@ -80,10 +72,10 @@ index 9010fd18a..667d98533 100644
  
  exclude (
 diff --git a/go.sum b/go.sum
-index 9691c6113..6e6828d13 100644
+index 7342f892f..20312a211 100644
 --- a/go.sum
 +++ b/go.sum
-@@ -33,8 +33,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
+@@ -35,8 +35,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
  github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
  github.com/containerd/btrfs/v2 v2.0.0 h1:FN4wsx7KQrYoLXN7uLP0vBV4oVWHOIKDRQ1G2Z0oL5M=
  github.com/containerd/btrfs/v2 v2.0.0/go.mod h1:swkD/7j9HApWpzl8OHfrHNxppPd9l44DFZdF94BUj9k=
@@ -94,7 +86,7 @@ index 9691c6113..6e6828d13 100644
  github.com/containerd/console v1.0.4 h1:F2g4+oChYvBTsASRTz8NP6iIAi97J3TtSAsLbIFn4ro=
  github.com/containerd/console v1.0.4/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
  github.com/containerd/containerd/api v1.9.0 h1:HZ/licowTRazus+wt9fM6r/9BQO7S0vD5lMcWspGIg0=
-@@ -55,8 +55,8 @@ github.com/containerd/imgcrypt/v2 v2.0.1 h1:gQcmeCKA97fAl0wlpq0itSY/PagFBsn4/mlK
+@@ -57,8 +57,8 @@ github.com/containerd/imgcrypt/v2 v2.0.1 h1:gQcmeCKA97fAl0wlpq0itSY/PagFBsn4/mlK
  github.com/containerd/imgcrypt/v2 v2.0.1/go.mod h1:/qIJL8nxzdzMA2n5iYyyuIY36KfoVQWmgTWdfVtyebM=
  github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
  github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
@@ -104,16 +96,16 @@ index 9691c6113..6e6828d13 100644
 +github.com/containerd/nri v0.10.1-0.20251117084425-3827d9da021a/go.mod h1:E3g/ifmXr7HQxKSkc4RETsp4z5YjUe2AVqGPIAL1Y2E=
  github.com/containerd/otelttrpc v0.1.0 h1:UOX68eVTE8H/T45JveIg+I22Ev2aFj4qPITCmXsskjw=
  github.com/containerd/otelttrpc v0.1.0/go.mod h1:XhoA2VvaGPW1clB2ULwrBZfXVuEWuyOd2NUD1IM0yTg=
- github.com/containerd/platforms v1.0.0-rc.1 h1:83KIq4yy1erSRgOVHNk1HYdPvzdJ5CnsWaRoJX4C41E=
-@@ -165,7 +165,6 @@ github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J
- github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
+ github.com/containerd/platforms v1.0.0-rc.2 h1:0SPgaNZPVWGEi4grZdV8VRYQn78y+nm6acgLGv/QzE4=
+@@ -168,7 +168,6 @@ github.com/google/pprof v0.0.0-20250820193118-f64d9cf942d6 h1:EEHtgt9IwisQ2AZ4pI
+ github.com/google/pprof v0.0.0-20250820193118-f64d9cf942d6/go.mod h1:I6V7YzU0XDpsHqbsyrghnFZLO1gwK6NPTNvmetQIk9U=
  github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
  github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 -github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
  github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
  github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
  github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
-@@ -197,6 +196,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
+@@ -200,6 +199,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
  github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
  github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
  github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
@@ -122,7 +114,7 @@ index 9691c6113..6e6828d13 100644
  github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
  github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
  github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
-@@ -218,11 +219,12 @@ github.com/miekg/pkcs11 v1.1.1 h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU=
+@@ -221,11 +222,12 @@ github.com/miekg/pkcs11 v1.1.1 h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU=
  github.com/miekg/pkcs11 v1.1.1/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
  github.com/mistifyio/go-zfs/v3 v3.0.1 h1:YaoXgBePoMA12+S1u/ddkv+QqxcfiZK4prI6HPnkFiU=
  github.com/mistifyio/go-zfs/v3 v3.0.1/go.mod h1:CzVgeB0RvF2EGzQnytKVvVSDwmKJXxkOTUGbNrTja/k=
@@ -136,7 +128,7 @@ index 9691c6113..6e6828d13 100644
  github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=
  github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBLGws92L2RU4=
  github.com/moby/sys/sequential v0.6.0 h1:qrx7XFUd/5DxtqcoH1h438hF5TmOvzC/lspjy7zgvCU=
-@@ -242,7 +244,6 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
+@@ -245,7 +247,6 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
  github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
  github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
  github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
@@ -144,7 +136,7 @@ index 9691c6113..6e6828d13 100644
  github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
  github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
  github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-@@ -256,12 +257,10 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
+@@ -259,12 +260,10 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
  github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
  github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
  github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
@@ -158,10 +150,10 @@ index 9691c6113..6e6828d13 100644
 +github.com/opencontainers/runtime-spec v1.3.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 +github.com/opencontainers/runtime-tools v0.9.1-0.20251114084447-edf4cb3d2116 h1:tAKu3NkKWZYpqBSOJKwTxT1wIGueiF7gcmcNgr5pNTY=
 +github.com/opencontainers/runtime-tools v0.9.1-0.20251114084447-edf4cb3d2116/go.mod h1:DKDEfzxvRkoQ6n9TGhxQgg2IM1lY4aM0eaQP4e3oElw=
- github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplUkdTrmPb8=
- github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
+ github.com/opencontainers/selinux v1.13.1 h1:A8nNeceYngH9Ow++M+VVEwJVpdFmrlxsN22F+ISDCJE=
+ github.com/opencontainers/selinux v1.13.1/go.mod h1:S10WXZ/osk2kWOYKy1x2f/eXF5ZHJoUs8UU/2caNRbg=
  github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
-@@ -299,7 +298,6 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
+@@ -302,7 +301,6 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
  github.com/sasha-s/go-deadlock v0.3.5 h1:tNCOEEDG6tBqrNDOX35j/7hL5FcFViG6awUGROb2NsU=
  github.com/sasha-s/go-deadlock v0.3.5/go.mod h1:bugP6EGbdGYObIlx7pUZtWqlvo8k9H6vCBBsiChJQ5U=
  github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -169,7 +161,7 @@ index 9691c6113..6e6828d13 100644
  github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
  github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
  github.com/smallstep/pkcs7 v0.1.1 h1:x+rPdt2W088V9Vkjho4KtoggyktZJlMduZAtRHm68LU=
-@@ -322,11 +320,10 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
+@@ -325,11 +323,10 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
  github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
  github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
  github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
@@ -182,8 +174,8 @@ index 9691c6113..6e6828d13 100644
 +github.com/tetratelabs/wazero v1.9.0/go.mod h1:TSbcXCfFP0L2FGkRPxHphadXPjo1T6W+CseNNY7EkjM=
  github.com/urfave/cli/v2 v2.27.6 h1:VdRdS98FNhKZ8/Az8B7MTyGQmpIr36O1EHybx/LaZ4g=
  github.com/urfave/cli/v2 v2.27.6/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5hrMvTQ=
- github.com/vishvananda/netlink v1.3.1-0.20250303224720-0e7078ed04c8 h1:Y4egeTrP7sccowz2GWTJVtHlwkZippgBTpUmMteFUWQ=
-@@ -336,7 +333,6 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
+ github.com/vishvananda/netlink v1.3.1 h1:3AEMt62VKqz90r0tmNhog0r/PpWKmrEShJU0wJW6bV0=
+@@ -338,7 +335,6 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
  github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
  github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
  github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
@@ -191,7 +183,7 @@ index 9691c6113..6e6828d13 100644
  github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
  github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
  github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
-@@ -449,8 +445,6 @@ golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5h
+@@ -453,8 +449,6 @@ golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5h
  golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
  golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -200,7 +192,7 @@ index 9691c6113..6e6828d13 100644
  golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
  golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
  golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-@@ -546,7 +540,6 @@ gopkg.in/evanphx/json-patch.v4 v4.12.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWM
+@@ -550,7 +544,6 @@ gopkg.in/evanphx/json-patch.v4 v4.12.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWM
  gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
  gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
  gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
@@ -208,7 +200,7 @@ index 9691c6113..6e6828d13 100644
  gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
  gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
  gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-@@ -576,7 +569,7 @@ sigs.k8s.io/structured-merge-diff/v4 v4.4.2 h1:MdmvkGuXi/8io6ixD5wud3vOLwc1rj0aN
+@@ -580,7 +573,7 @@ sigs.k8s.io/structured-merge-diff/v4 v4.4.2 h1:MdmvkGuXi/8io6ixD5wud3vOLwc1rj0aN
  sigs.k8s.io/structured-merge-diff/v4 v4.4.2/go.mod h1:N8f93tFZh9U6vpxwRArLiikrE5/2tiu1w1AGfACIGE4=
  sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
  sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
@@ -114336,7 +114328,7 @@ index 000000000..1a7070f48
 +	return defaultStatFromFileInfo(info)
 +}
 diff --git a/vendor/modules.txt b/vendor/modules.txt
-index 374d8e06d..9766f900f 100644
+index 1f5fab508..196d63b8d 100644
 --- a/vendor/modules.txt
 +++ b/vendor/modules.txt
 @@ -95,7 +95,7 @@ github.com/cilium/ebpf/link
@@ -114371,7 +114363,7 @@ index 374d8e06d..9766f900f 100644
  github.com/containerd/nri/types/v1
  # github.com/containerd/otelttrpc v0.1.0
  ## explicit; go 1.21
-@@ -345,6 +349,9 @@ github.com/klauspost/compress/internal/le
+@@ -357,6 +361,9 @@ github.com/klauspost/compress/internal/le
  github.com/klauspost/compress/internal/snapref
  github.com/klauspost/compress/zstd
  github.com/klauspost/compress/zstd/internal/xxhash
@@ -114381,7 +114373,7 @@ index 374d8e06d..9766f900f 100644
  # github.com/mdlayher/socket v0.5.1
  ## explicit; go 1.20
  github.com/mdlayher/socket
-@@ -364,6 +371,9 @@ github.com/moby/locker
+@@ -376,6 +383,9 @@ github.com/moby/locker
  ## explicit; go 1.13
  github.com/moby/spdystream
  github.com/moby/spdystream/spdy
@@ -114391,7 +114383,7 @@ index 374d8e06d..9766f900f 100644
  # github.com/moby/sys/mountinfo v0.7.2
  ## explicit; go 1.17
  github.com/moby/sys/mountinfo
-@@ -403,12 +413,12 @@ github.com/opencontainers/go-digest/digestset
+@@ -415,12 +425,12 @@ github.com/opencontainers/go-digest/digestset
  github.com/opencontainers/image-spec/identity
  github.com/opencontainers/image-spec/specs-go
  github.com/opencontainers/image-spec/specs-go/v1
@@ -114407,7 +114399,7 @@ index 374d8e06d..9766f900f 100644
  github.com/opencontainers/runtime-tools/generate
  github.com/opencontainers/runtime-tools/generate/seccomp
  github.com/opencontainers/runtime-tools/validate/capabilities
-@@ -474,12 +484,46 @@ github.com/stefanberger/go-pkcs11uri
+@@ -486,12 +496,46 @@ github.com/stefanberger/go-pkcs11uri
  github.com/stretchr/testify/assert
  github.com/stretchr/testify/assert/yaml
  github.com/stretchr/testify/require
@@ -114457,7 +114449,7 @@ index 374d8e06d..9766f900f 100644
  # github.com/urfave/cli/v2 v2.27.6
  ## explicit; go 1.18
  github.com/urfave/cli/v2
-@@ -888,12 +932,12 @@ sigs.k8s.io/structured-merge-diff/v4/value
+@@ -900,12 +944,12 @@ sigs.k8s.io/structured-merge-diff/v4/value
  ## explicit; go 1.12
  sigs.k8s.io/yaml
  sigs.k8s.io/yaml/goyaml.v2


### PR DESCRIPTION
Update the cgroups patch.

See https://github.com/containerd/containerd/releases/tag/v2.1.6

(direct to v1.12 as main is on v2.2.0)