### PR TITLE
Add lvmd 

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -40,6 +40,7 @@ spec:
     - liburcu
     - linux-firmware
     - lvm2
+    - lvmd
     - mtools
     - musl
     - nftables

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ TARGETS += libsepol
 TARGETS += liburcu
 TARGETS += linux-firmware
 TARGETS += lvm2
+TARGETS += lvmd
 TARGETS += mtools
 TARGETS += musl
 TARGETS += nftables

--- a/Pkgfile
+++ b/Pkgfile
@@ -192,6 +192,11 @@ vars:
   lvm2_sha256: 322d44bf40de318e6e6b52c56999aaeb86b16c8267187ac2e01a44d4dc526960
   lvm2_sha512: 97fd1849cd632943c8233f06f181b1899b0e6937444d672abef10307c66d207c16325701ac669d5ff438490a11596c19d1dbbcff50e4e7c00c9b6e4eb1ecf87c
 
+  # renovate: datasource=github-releases extractVersion=^v(?<version>.*)$ depName=topolvm/topolvm
+  lvmd_version: v0.39.0
+  lvmd_sha256: 03df778981d200d7da482753a2e23988457c0231da0a3e8a463538f0d19fb675
+  lvmd_sha512: 5c5062aa9b773d180784b6a1a91566c746cd11ab9ca29d48be17c5217e758005b7e80e8c1257a233f9335572d60774fb6154e662c5569699ff38d1762e6f683a
+
   # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=Mellanox/mstflint
   mellanox_mstflint_version: 4.31.0-1
   mellanox_mstflint_sha256: 91006fffaee68b0ea548721c095632eba07b3875687c5b3637e7afb6c4373af9

--- a/lvmd/pkg.yaml
+++ b/lvmd/pkg.yaml
@@ -1,0 +1,43 @@
+name: lvmd
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+  - stage: lvm2
+steps:
+  - sources:
+      - url: https://github.com/topolvm/topolvm/archive/refs/tags/{{ .lvmd_version }}.tar.gz
+        destination: topolvm.tar.gz
+        sha256: "{{ .lvmd_sha256 }}"
+        sha512: "{{ .lvmd_sha512 }}"
+  - network: default
+    prepare:
+      - |
+        tar -xzf topolvm.tar.gz --strip-components=1
+        go mod download
+        go mod verify
+  - network: none
+    build:
+      - |
+        export GOARCH=$(go env GOARCH)
+        CGO_ENABLED=0 go build \
+          -ldflags="-s -w -X github.com/topolvm/topolvm.Version={{ .lvmd_version }}" \
+          -o lvmd ./cmd/lvmd
+    install:
+      - |
+        mkdir -p /rootfs/usr/bin
+        install -D -m 0755 lvmd /rootfs/usr/bin/lvmd
+    test:
+      - |
+        fhs-validator /rootfs
+    sbom:
+      outputPath: /rootfs/usr/share/spdx/lvmd.spdx.json
+      version: {{ .lvmd_version }}
+      cpes:
+        - cpe:2.3:a:topolvm:lvmd:{{ .lvmd_version }}:*:*:*:*:*:*:*
+        - cpe:2.3:a:topolvm:topolvm:{{ .lvmd_version }}:*:*:*:*:*:*:*
+      licenses:
+        - Apache-2.0
+finalize:
+  - from: /rootfs
+    to: /


### PR DESCRIPTION
Add lvmd as a talos package, allowing CSI drivers to manage logical volumes without direct access to host block devices.

CSI components communicate with lvmd over a gRPC interface and lvmd performs actual LVM operations using the host's lvm2 tools. This avoids the need to run privileged CSI containers or mount host devices like `/dev` for supporting LVM (Creating LV's using CSI)

Reference : https://github.com/topolvm/topolvm/blob/main/docs/lvmd.md
This PR helps to continue work in : https://github.com/siderolabs/talos/pull/12530