### PR TITLE
feat: update OpenSSL to v3.6.1

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@ format: v1alpha2
 vars:
   TOOLCHAIN_MUSL_IMAGE: ghcr.io/siderolabs/toolchain-musl:v1.13.0-alpha.0-3-g3a527b1
   TOOLS_PREFIX: ghcr.io/siderolabs/
-  TOOLS_REV: v1.13.0-alpha.0-10-g721ad07
+  TOOLS_REV: v1.13.0-alpha.0-11-g0281af0
 
   # renovate: datasource=github-releases depName=containernetworking/plugins
   cni_version: v1.9.0


### PR DESCRIPTION
Via tools: https://github.com/siderolabs/tools/pull/509