### PR TITLE
fix: make udev rules read only

### DIFF
--- a/systemd-udevd/pkg.yaml
+++ b/systemd-udevd/pkg.yaml
@@ -33,6 +33,7 @@ steps:
         rm /rootfs/usr/lib/udev/rules.d/{README,60-cdrom_id.rules,60-persistent-alsa.rules,60-persistent-v4l.rules,64-btrfs.rules,70-joystick.rules,70-mouse.rules,70-touchpad.rules,78-sound-card.rules,90-vconsole.rules,99-systemd.rules}
         # Azure csi support
         cp /pkg/files/66-azure.rules /rootfs/usr/lib/udev/rules.d/66-azure.rules
+        chmod -w /rootfs/usr/lib/udev/rules.d/*
     test:
       - |
         fhs-validator /rootfs


### PR DESCRIPTION
Remove writable bit even if it doesn't actually matter