### PR TITLE
feat: add containerd patch to verify images

### DIFF
--- a/containerd/patches/image-verify.patch
+++ b/containerd/patches/image-verify.patch
@@ -1,0 +1,363 @@
+diff --git a/integration/image_pull_timeout_test.go b/integration/image_pull_timeout_test.go
+index c70fa9717..3fe3e1cb7 100644
+--- a/integration/image_pull_timeout_test.go
++++ b/integration/image_pull_timeout_test.go
+@@ -93,7 +93,7 @@ func testCRIImagePullTimeoutBySlowCommitWriter(t *testing.T, useLocal bool) {
+ 
+ 	ctx := namespaces.WithNamespace(logtest.WithT(context.Background(), t), k8sNamespace)
+ 
+-	_, err = criService.PullImage(ctx, pullProgressTestImageName, nil, nil, "")
++	_, err = criService.PullImage(ctx, pullProgressTestImageName, nil, nil, nil, "")
+ 	assert.NoError(t, err)
+ }
+ 
+@@ -220,7 +220,7 @@ func testCRIImagePullTimeoutByHoldingContentOpenWriter(t *testing.T, useLocal bo
+ 	go func() {
+ 		defer close(errCh)
+ 
+-		_, err := criService.PullImage(ctx, pullProgressTestImageName, nil, nil, "")
++		_, err := criService.PullImage(ctx, pullProgressTestImageName, nil, nil, nil, "")
+ 		errCh <- err
+ 	}()
+ 
+@@ -316,7 +316,7 @@ func testCRIImagePullTimeoutByNoDataTransferred(t *testing.T, useLocal bool) {
+ 		dctx, _, err := cli.WithLease(ctx)
+ 		assert.NoError(t, err)
+ 
+-		_, err = criService.PullImage(dctx, fmt.Sprintf("%s/%s", mirrorURL.Host, "containerd/volume-ownership:2.1"), nil, nil, "")
++		_, err = criService.PullImage(dctx, fmt.Sprintf("%s/%s", mirrorURL.Host, "containerd/volume-ownership:2.1"), nil, nil, nil, "")
+ 
+ 		assert.Equal(t, context.Canceled, errors.Unwrap(err), "[%v] expected canceled error, but got (%v)", idx, err)
+ 		assert.True(t, mirrorSrv.limiter.clearHitCircuitBreaker(), "[%v] expected to hit circuit breaker", idx)
+diff --git a/internal/cri/server/container_status_test.go b/internal/cri/server/container_status_test.go
+index aad56f56a..8d08d4b7a 100644
+--- a/internal/cri/server/container_status_test.go
++++ b/internal/cri/server/container_status_test.go
+@@ -302,7 +302,7 @@ func (s *fakeImageService) ImageFSPaths() map[string]string { return make(map[st
+ 
+ func (s *fakeImageService) DisableSnapshotAnnotations() bool { return false }
+ 
+-func (s *fakeImageService) PullImage(context.Context, string, func(string) (string, string, error), *runtime.PodSandboxConfig, string) (string, error) {
++func (s *fakeImageService) PullImage(context.Context, string, func(string) (string, string, error), *runtime.AuthConfig, *runtime.PodSandboxConfig, string) (string, error) {
+ 	return "", errors.New("not implemented")
+ }
+ 
+diff --git a/internal/cri/server/images/image_pull.go b/internal/cri/server/images/image_pull.go
+index d94b47be7..a30d2ce3d 100644
+--- a/internal/cri/server/images/image_pull.go
++++ b/internal/cri/server/images/image_pull.go
+@@ -113,14 +113,14 @@ func (c *GRPCCRIImageService) PullImage(ctx context.Context, r *runtime.PullImag
+ 		return ParseAuth(hostauth, host)
+ 	}
+ 
+-	ref, err := c.CRIImageService.PullImage(ctx, imageRef, credentials, r.SandboxConfig, r.GetImage().GetRuntimeHandler())
++	ref, err := c.CRIImageService.PullImage(ctx, imageRef, credentials, r.Auth, r.SandboxConfig, r.GetImage().GetRuntimeHandler())
+ 	if err != nil {
+ 		return nil, err
+ 	}
+ 	return &runtime.PullImageResponse{ImageRef: ref}, nil
+ }
+ 
+-func (c *CRIImageService) PullImage(ctx context.Context, name string, credentials func(string) (string, string, error), sandboxConfig *runtime.PodSandboxConfig, runtimeHandler string) (_ string, err error) {
++func (c *CRIImageService) PullImage(ctx context.Context, name string, credentials func(string) (string, string, error), authConfig *runtime.AuthConfig, sandboxConfig *runtime.PodSandboxConfig, runtimeHandler string) (_ string, err error) {
+ 	span := tracing.SpanFromContext(ctx)
+ 	defer func() {
+ 		// TODO: add domain label for imagePulls metrics, and we may need to provide a mechanism
+@@ -182,7 +182,7 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
+ 	// TODO: Add support for DisableSnapshotAnnotations, DiscardUnpackedLayers, ImagePullWithSyncFs and unpackDuplicationSuppressor
+ 	var image containerd.Image
+ 	if c.config.UseLocalImagePull {
+-		image, err = c.pullImageWithLocalPull(ctx, ref, credentials, snapshotter, labels, imagePullProgressTimeout)
++		image, err = c.pullImageWithLocalPull(ctx, ref, credentials, authConfig, snapshotter, labels, imagePullProgressTimeout)
+ 	} else {
+ 		image, err = c.pullImageWithTransferService(ctx, ref, credentials, snapshotter, labels, imagePullProgressTimeout)
+ 	}
+@@ -236,6 +236,7 @@ func (c *CRIImageService) pullImageWithLocalPull(
+ 	ctx context.Context,
+ 	ref string,
+ 	credentials func(string) (string, string, error),
++	authConfig *runtime.AuthConfig,
+ 	snapshotter string,
+ 	labels map[string]string,
+ 	imagePullProgressTimeout time.Duration,
+@@ -248,6 +249,15 @@ func (c *CRIImageService) pullImageWithLocalPull(
+ 		Hosts:   c.registryHosts(ctx, credentials, pullReporter.optionUpdateClient),
+ 	})
+ 
++	digestedRef, err := c.talosVerifyImage(ctx, ref, authConfig, labels)
++	if err != nil {
++		return nil, fmt.Errorf("failed to verify image %q with talos: %w", ref, err)
++	}
++
++	if digestedRef != "" {
++		ref = digestedRef
++	}
++
+ 	log.G(ctx).Debugf("PullImage %q with snapshotter %s using client.Pull()", ref, snapshotter)
+ 	pullOpts := []containerd.RemoteOpt{
+ 		containerd.WithResolver(resolver),
+diff --git a/internal/cri/server/images/image_talos.go b/internal/cri/server/images/image_talos.go
+new file mode 100644
+index 000000000..d563313db
+--- /dev/null
++++ b/internal/cri/server/images/image_talos.go
+@@ -0,0 +1,220 @@
++package images
++
++import (
++	"context"
++	"fmt"
++	"net/url"
++	"sync"
++
++	"google.golang.org/grpc"
++	"google.golang.org/grpc/credentials/insecure"
++	"google.golang.org/grpc/metadata"
++	"google.golang.org/protobuf/encoding/protowire"
++	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
++)
++
++const (
++	machineSocketPath = "/system/run/machined/machine.sock"
++	roleMdKey         = "talos-role"
++	readerRole        = "os:reader"
++	labelVerified     = "talos.dev/verified"
++)
++
++// Protobuf API definition we are going to call:
++//
++//	// Verify an image signature.
++//	rpc Verify(ImageServiceVerifyRequest) returns (ImageServiceVerifyResponse);
++//
++// message ImageServiceVerifyRequest {
++//
++//	// Image reference to verify.
++//	string image_ref = 1;
++//	// Authentication credentials for the registry (if needed).
++//	ImageServiceCredentials credentials = 2;
++//
++// }
++//
++// message ImageServiceCredentials {
++//
++//	string host = 1;
++//	string username = 2;
++//	string password = 3;
++//
++// }
++//
++// message ImageServiceVerifyResponse {
++//
++//	bool verified = 1;
++//	string message = 2;
++//	string digested_image_ref = 3;
++//
++// }
++
++// rawBytesCodec is a gRPC codec that passes []byte through without re-marshaling,
++// allowing us to use protowire-encoded bytes directly.
++type rawBytesCodec struct{}
++
++func (rawBytesCodec) Name() string { return "proto" }
++
++func (rawBytesCodec) Marshal(v any) ([]byte, error) {
++	b, ok := v.([]byte)
++	if !ok {
++		return nil, fmt.Errorf("rawBytesCodec: expected []byte, got %T", v)
++	}
++
++	return b, nil
++}
++
++func (rawBytesCodec) Unmarshal(data []byte, v any) error {
++	b, ok := v.(*[]byte)
++	if !ok {
++		return fmt.Errorf("rawBytesCodec: expected *[]byte, got %T", v)
++	}
++
++	*b = data
++
++	return nil
++}
++
++var talosClient = sync.OnceValue(func() *grpc.ClientConn {
++	cli, err := grpc.NewClient("unix:///"+machineSocketPath,
++		grpc.WithTransportCredentials(insecure.NewCredentials()),
++		grpc.WithNoProxy(),
++	)
++	if err != nil {
++		panic(fmt.Sprintf("failed to create gRPC client for Talos machine API: %v", err))
++	}
++
++	return cli
++})
++
++func (c *CRIImageService) talosVerifyImage(ctx context.Context, ref string, authConfig *runtime.AuthConfig, labels map[string]string) (string, error) {
++	cli := talosClient()
++
++	ctx = metadata.NewOutgoingContext(ctx, metadata.MD{
++		roleMdKey: []string{readerRole},
++	})
++
++	// decode auth config into ImageServiceCredentials:
++	var (
++		host string
++		user string
++		pass string
++	)
++
++	if authConfig != nil && authConfig.ServerAddress != "" {
++		u, err := url.Parse(authConfig.ServerAddress)
++		if err == nil {
++			host = u.Host
++
++			user, pass, err = ParseAuth(authConfig, host)
++			if err != nil {
++				return "", fmt.Errorf("failed to parse auth config: %w", err)
++			}
++		}
++	}
++
++	// Encode ImageServiceVerifyRequest using protowire:
++	//   field 1 (string): image_ref
++	var reqBuf []byte
++	reqBuf = protowire.AppendTag(reqBuf, 1, protowire.BytesType)
++	reqBuf = protowire.AppendString(reqBuf, ref)
++
++	//   field 2 (message): credentials
++	if host != "" || user != "" || pass != "" {
++		var credBuf []byte
++
++		if host != "" {
++			credBuf = protowire.AppendTag(credBuf, 1, protowire.BytesType)
++			credBuf = protowire.AppendString(credBuf, host)
++		}
++
++		if user != "" {
++			credBuf = protowire.AppendTag(credBuf, 2, protowire.BytesType)
++			credBuf = protowire.AppendString(credBuf, user)
++		}
++
++		if pass != "" {
++			credBuf = protowire.AppendTag(credBuf, 3, protowire.BytesType)
++			credBuf = protowire.AppendString(credBuf, pass)
++		}
++
++		reqBuf = protowire.AppendTag(reqBuf, 2, protowire.BytesType)
++		reqBuf = protowire.AppendBytes(reqBuf, credBuf)
++	}
++
++	var respBuf []byte
++
++	err := cli.Invoke(
++		ctx,
++		"/machine.ImageService/Verify",
++		reqBuf,
++		&respBuf,
++		grpc.ForceCodec(rawBytesCodec{}),
++	)
++	if err != nil {
++		return "", fmt.Errorf("failed to verify: %w", err)
++	}
++
++	// Decode ImageServiceVerifyResponse:
++	//   field 1 (bool/varint): verified
++	//   field 2 (string):      message
++	//   field 3 (string):      digested_image_ref
++	var (
++		verified         bool
++		message          string
++		digestedImageRef string
++	)
++
++	for len(respBuf) > 0 {
++		num, typ, n := protowire.ConsumeTag(respBuf)
++		if n < 0 {
++			return "", fmt.Errorf("failed to parse response tag: %w", protowire.ParseError(n))
++		}
++
++		respBuf = respBuf[n:]
++
++		switch {
++		case num == 1 && typ == protowire.VarintType:
++			v, n := protowire.ConsumeVarint(respBuf)
++			if n < 0 {
++				return "", fmt.Errorf("failed to parse verified field: %w", protowire.ParseError(n))
++			}
++
++			verified = v != 0
++			respBuf = respBuf[n:]
++		case num == 2 && typ == protowire.BytesType:
++			v, n := protowire.ConsumeString(respBuf)
++			if n < 0 {
++				return "", fmt.Errorf("failed to parse message field: %w", protowire.ParseError(n))
++			}
++
++			message = v
++			respBuf = respBuf[n:]
++		case num == 3 && typ == protowire.BytesType:
++			v, n := protowire.ConsumeString(respBuf)
++			if n < 0 {
++				return "", fmt.Errorf("failed to parse digested_image_ref field: %w", protowire.ParseError(n))
++			}
++
++			digestedImageRef = v
++			respBuf = respBuf[n:]
++		default:
++			// Skip unknown or unneeded fields.
++			n := protowire.ConsumeFieldValue(num, typ, respBuf)
++			if n < 0 {
++				return "", fmt.Errorf("failed to skip field %d: %w", num, protowire.ParseError(n))
++			}
++
++			respBuf = respBuf[n:]
++		}
++	}
++
++	if !verified {
++		return "", nil
++	}
++
++	labels[labelVerified] = message
++
++	return digestedImageRef, nil
++}
+diff --git a/internal/cri/server/podsandbox/controller.go b/internal/cri/server/podsandbox/controller.go
+index e3828bc0b..c0344a712 100644
+--- a/internal/cri/server/podsandbox/controller.go
++++ b/internal/cri/server/podsandbox/controller.go
+@@ -121,7 +121,7 @@ type RuntimeService interface {
+ type ImageService interface {
+ 	LocalResolve(refOrID string) (imagestore.Image, error)
+ 	GetImage(id string) (imagestore.Image, error)
+-	PullImage(ctx context.Context, name string, creds func(string) (string, string, error), sc *runtime.PodSandboxConfig, runtimeHandler string) (string, error)
++	PullImage(ctx context.Context, name string, creds func(string) (string, string, error), ac *runtime.AuthConfig, sc *runtime.PodSandboxConfig, runtimeHandler string) (string, error)
+ 	RuntimeSnapshotter(ctx context.Context, ociRuntime criconfig.Runtime) string
+ 	PinnedImage(string) string
+ 	DisableSnapshotAnnotations() bool
+diff --git a/internal/cri/server/podsandbox/sandbox_run.go b/internal/cri/server/podsandbox/sandbox_run.go
+index 15fd3398f..d08ebfcb4 100644
+--- a/internal/cri/server/podsandbox/sandbox_run.go
++++ b/internal/cri/server/podsandbox/sandbox_run.go
+@@ -331,7 +331,7 @@ func (c *Controller) ensureImageExists(ctx context.Context, ref string, config *
+ 	}
+ 	// Pull image to ensure the image exists
+ 	// TODO: Cleaner interface
+-	imageID, err := c.imageService.PullImage(ctx, ref, nil, config, runtimeHandler)
++	imageID, err := c.imageService.PullImage(ctx, ref, nil, nil, config, runtimeHandler)
+ 	if err != nil {
+ 		return nil, fmt.Errorf("failed to pull image %q: %w", ref, err)
+ 	}
+diff --git a/internal/cri/server/service.go b/internal/cri/server/service.go
+index 87eb02e42..a707f5ea5 100644
+--- a/internal/cri/server/service.go
++++ b/internal/cri/server/service.go
+@@ -96,7 +96,7 @@ type RuntimeService interface {
+ type ImageService interface {
+ 	RuntimeSnapshotter(ctx context.Context, ociRuntime criconfig.Runtime) string
+ 
+-	PullImage(ctx context.Context, name string, credentials func(string) (string, string, error), sandboxConfig *runtime.PodSandboxConfig, runtimeHandler string) (string, error)
++	PullImage(ctx context.Context, name string, credentials func(string) (string, string, error), authConfig *runtime.AuthConfig, sandboxConfig *runtime.PodSandboxConfig, runtimeHandler string) (string, error)
+ 	UpdateImage(ctx context.Context, r string) error
+ 
+ 	CheckImages(ctx context.Context) error

--- a/containerd/pkg.yaml
+++ b/containerd/pkg.yaml
@@ -17,6 +17,8 @@ steps:
     prepare:
       - |
         tar -xzf containerd.tar.gz --strip-components=1
+      - |
+        patch -p1 < /pkg/patches/image-verify.patch
     build:
       - |
         make VERSION={{ .containerd_version }} REVISION={{ .containerd_ref }} STATIC=1


### PR DESCRIPTION
The patch calls back into Talos machined API to verify each image being pulled, and if verified, pulls by the pinned digest.

See https://github.com/siderolabs/talos/pull/12853 for the context.