### PR TITLE
feat: update Go to 1.26.1

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-12-11T12:37:10Z by kres 4b09af7.
+# Generated on 2026-03-06T15:33:29Z by kres 1dd7316.
 
 "on":
   schedule:
@@ -15,7 +15,7 @@ jobs:
       - ubuntu-latest
     steps:
       - name: Close stale issues and PRs
-        uses: actions/stale@997185467fa4f803885201cee163a9f38240193d # version: v10.1.1
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # version: v10.2.0
         with:
           close-issue-message: This issue was closed because it has been stalled for 7 days with no activity.
           days-before-issue-close: "5"

--- a/Pkgfile
+++ b/Pkgfile
@@ -3,9 +3,9 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_MUSL_IMAGE: ghcr.io/siderolabs/toolchain-musl:v1.13.0-alpha.0-5-g5657601
+  TOOLCHAIN_MUSL_IMAGE: ghcr.io/siderolabs/toolchain-musl:v1.13.0-alpha.0-6-g5b44ff9
   TOOLS_PREFIX: ghcr.io/siderolabs/
-  TOOLS_REV: v1.13.0-alpha.0-16-g9de9770
+  TOOLS_REV: v1.13.0-alpha.0-17-gf175a91
   LLVM_IMAGE: ghcr.io/siderolabs/llvm
 
   # renovate: datasource=github-releases depName=containernetworking/plugins
@@ -45,9 +45,9 @@ vars:
   ena_sha512: 63d53d0377252c8e25486be4d9df5b9af2bbe99916b348ba3960182c5d0cbc82130b636ff28c006de23f6ff9ff526679c3ecbf4ee19ea65660b411c9da66a34c
 
   # renovate: datasource=github-releases extractVersion=^v(?<version>.*)$ depName=systemd/systemd
-  systemd_version: 259.1
-  systemd_sha256: 7af4f36db512ad2f0f749a0f9886370edeb2bb5128014fc47cdf73702c7e1911
-  systemd_sha512: 7cbeca5dad6413a876809200583854ddc706b7a69deff958eb1ca1afb726cf4dec014006c10d1945c450b754811d4b95a80fe1778cb3136997f6d11b11c0560e
+  systemd_version: 259.3
+  systemd_sha256: a1a1a52a63365a867b8ba71a4c66b513ff90eafe4935e6a079ffdfa29625980a
+  systemd_sha512: ea7314fcde3c0e541c9399f2d165f114bd7bf37cec294680964352da374435ddd3949432f939f35ecb49f0ce6a3b7aaaddf2b65cc8107abc65e2ec3806c99dac
 
   # renovate: datasource=github-releases depName=flannel-io/cni-plugin
   flannel_cni_version: v1.9.0-flannel1
@@ -73,9 +73,9 @@ vars:
   hailort_fw_sha512: 6280e4bddc120ab6e9a4a4fdac529816ee1f94d343e0e0ef6c36fd474b579f85032e22b24a8f758b23028d429ef5936780fa07ed3c0abc512f5fd72985fc982c
 
   # renovate: datasource=github-releases depName=intel/isa-l
-  igzip_version: 2.31.1
-  igzip_sha256: e1d5573a4019738243b568ab1e1422e6ab7557c5cae33cc8686944d327ad6bb4
-  igzip_sha512: 65199d054af1edc26d477883f7878f25fd4db65622aa98247069f1296c5f07b75da24f0361a6c3889ddb3168d940b508cd2f6340548a62ff3157977179fd002d
+  igzip_version: 2.32.0
+  igzip_sha256: 7a194ff80d0f7e20615c497654e8a51b0184d0c79e2e265c7f555f52a26a05a4
+  igzip_sha512: e09f6e6f39d60b06b7a62d0e5c0be5e86b26efc375235e84f7c9aa85f4706883e7f0b40cc9cbced4ac27db2f19ac9c36f45b93454652a36fe46aa297200d4aeb
 
   # renovate: datasource=github-releases extractVersion=^IPMITOOL_(?<version>.*)$ depName=ipmitool/ipmitool
   ipmitool_version: 1_8_19
@@ -83,14 +83,14 @@ vars:
   ipmitool_sha512: 2d91706e9feba4b2ce4808eca087b81b842c4292a5840830001919c06ec8babd8f8761b74bb9dcf8fbc7765f028a5b1a192a3c1b643f2adaa157fed6fb0d1ee3
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.netfilter.org/iptables
-  iptables_version: 1.8.12
-  iptables_sha256: 8e7ee962601492de6503d171d4a948092ab18f89f111de72e3037c1f40cfb846
-  iptables_sha512: b25bd6f6f78a6192699bce44c2b29ca65351ef71198a84fa26d29c47cb24ed695ee0406f6581fa81ece4d30445bb0680def5dc328f7fc708b80cadcd0230fe49
+  iptables_version: 1.8.13
+  iptables_sha256: 1afcd33da9e8f913ace6a2126788162e207e26f5d5e29c6573c0e581ffc58b99
+  iptables_sha512: 3aefd76ca60d00f46ba4d6f39cbcfdc60517d03b6714da25dcd67542f6f4eea8d82c4855bdd9124efe18b769f41951772b8340a6eda75b85f8dd52b2289b145b
 
   # renovate: datasource=git-refs versioning=git depName=https://github.com/ipxe/ipxe.git
-  ipxe_ref: 1b6d88d6461d064817821e25de2aca62621ae202
-  ipxe_sha256: 3abbda262d2749b3f2953f5ee0e97ad215e00d84b118ad8da8fb9c81e8c754df
-  ipxe_sha512: 1176294be317710000554a8363efa1b515873a22665b5c06bf9d23ed147118950667042cd042ae9dec5851a30d41cf0e22ccd653e79c36a5ab7ab91e77a0e839
+  ipxe_ref: 94138656d74a5f787ca6c6dd22c08e656ac131f3
+  ipxe_sha256: 163cad5da47df64a69dd2c55118df1a064139258dfa0e2f87207015441348480
+  ipxe_sha512: 6ed5a585303e2c2dd3cb86fac0f7d8c847e8bd559bce48b02bd83a30e6ed58add0cb475da059916297b320a908f955cfddd6ddad395e718724527d40a45bfdf9
 
   # renovate: datasource=git-refs versioning=git depName=https://github.com/a13xp0p0v/kernel-hardening-checker.git
   kspp_ref: 93746f46678a36822a841fdb78f6de85392b5b03
@@ -235,9 +235,9 @@ vars:
   px_fuse_sha512: f34d645fe1f82a0a3c77a824865cc7e3038d4a0ba9cb0f3b6b30bd48e274b9bdb7f7e3e77fe6f09fca10db9b072e510dc0b877e7add5c00859e667542f2e4dc4
 
   # renovate: datasource=git-tags depName=https://gitlab.gnome.org/GNOME/glib.git
-  glib_version: 2.87.2
-  glib_sha256: d6eb74a4f4ffc0b56df79ae3a939463b1d92c623f6c167d51aab24e303a851f3
-  glib_sha512: 6156cdf2cf88672ba23c0ffb133af0dedd65b18df318ba3a99a691678c514af8a30680082ffc86f15c25050f49668382ea81aef9642cb28a4227a3e35aacbde8
+  glib_version: 2.87.3
+  glib_sha256: 8374eb3afcf9b6d21d5b5960b324922bb4960ffe438df5ceface9e4fafb2f0a4
+  glib_sha512: dce4e87e28fe3a9ab07c649ab59af7e7e0fed1bd310431ad50594f9357e8cbff9caee1a54d3c59734576df1884783cd33c4f51432517a6a2f0c6a41404ca6e56
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=https://github.com/qemu/qemu.git
   qemu_version: 10.2.1


### PR DESCRIPTION
Via tools/toolchain.

Also updated nonbackportable dependencies:

| Package | Type | Update | Change |
|---|---|---|---|
| git://git.netfilter.org/iptables |  | patch | `1.8.12` → `1.8.13` |
| https://github.com/ipxe/ipxe.git |  | digest | `1b6d88d` → `9413865` |
| [https://gitlab.gnome.org/GNOME/glib.git](https://gitlab.gnome.org/GNOME/glib) |  | patch | `2.87.2` → `2.87.3` |
| [intel/isa-l](https://redirect.github.com/intel/isa-l) |  | minor | `2.31.1` → `2.32.0` |
| [systemd/systemd](https://redirect.github.com/systemd/systemd) |  | minor | `259.1` → `259.3` |
