### PR TITLE
fix: install apparmor parser required config files

### DIFF
--- a/apparmor/pkg.yaml
+++ b/apparmor/pkg.yaml
@@ -26,13 +26,27 @@ steps:
       - |
         cd libraries/libapparmor
         make -j $(nproc)
-
-        cd ../../parser
+      - |
+        cd parser
         make arch -j $(nproc)
     install:
       - |
         cd parser
         DISTRO=unknown make install-arch DESTDIR=/rootfs SBINDIR=/rootfs/usr/bin
+
+        INSTALL_CONFDIR=/rootfs/etc/apparmor
+        install -m 755 -d ${INSTALL_CONFDIR}
+        install -m 644 parser.conf ${INSTALL_CONFDIR}
+      - |
+        cd profiles
+
+        PROFILES_DEST=/rootfs/etc/apparmor.d
+
+        install -m 755 -d ${PROFILES_DEST}
+        install -m 755 -d ${PROFILES_DEST}/disable
+
+        install -m 755 -d "${PROFILES_DEST}/abi"
+        install -m 644 ./apparmor.d/abi/3.0 ${PROFILES_DEST}/abi/3.0
     test:
       - |
         fhs-validator /rootfs


### PR DESCRIPTION
New package structure:

```
drwxr-xr-x 0/0               0 2019-06-02 01:34 etc
drwxr-xr-x 0/0               0 2019-06-02 01:34 etc/apparmor
-rw-r--r-- 0/0            2270 2019-06-02 01:34 etc/apparmor/parser.conf
drwxr-xr-x 0/0               0 2019-06-02 01:34 etc/apparmor.d
drwxr-xr-x 0/0               0 2019-06-02 01:34 etc/apparmor.d/abi
-rw-r--r-- 0/0            1925 2019-06-02 01:34 etc/apparmor.d/abi/3.0
drwxr-xr-x 0/0               0 2019-06-02 01:34 etc/apparmor.d/disable
drwxr-xr-x 0/0               0 2019-06-02 01:34 usr
drwxr-xr-x 0/0               0 2019-06-02 01:34 usr/bin
-rwxr-xr-x 0/0         1044984 2019-06-02 01:34 usr/bin/apparmor_parser
drwxr-xr-x 0/0               0 2019-06-02 01:34 usr/share
drwxr-xr-x 0/0               0 2019-06-02 01:34 usr/share/spdx
-rw-r--r-- 0/0            2875 2019-06-02 01:34 usr/share/spdx/apparmor.spdx.json
```

This fixes an error like:

```
parser error(\"Warning from stdin (line 1): config file '/etc/apparmor/parser.conf' not found\\nAppArmor parser error for /run/cri-containerd.apparmor.d2733786676 in profile /run/cri-containerd.apparmor.d2733786676 at line 2: Could not open 'abi/3.0': No error information\")
```