### PR TITLE
feat: preserve System.map on kernel builds

### DIFF
--- a/kernel/kernel/pkg.yaml
+++ b/kernel/kernel/pkg.yaml
@@ -35,9 +35,11 @@ steps:
             ;;
         esac
 
+        cp System.map /rootfs/boot/System.map
+
         export KERNELRELEASE=$(cat include/config/kernel.release)
         make -j $(nproc) modules_install INSTALL_MOD_PATH=/rootfs/usr INSTALL_MOD_STRIP=1
-        depmod -b /rootfs/usr $KERNELRELEASE
+        depmod -b /rootfs/usr -F /rootfs/boot/System.map --errsyms -w $KERNELRELEASE
         unlink /rootfs/usr/lib/modules/$KERNELRELEASE/build
     sbom:
       outputPath: /rootfs/usr/share/spdx/kernel.spdx.json

--- a/libarchive/pkg.yaml
+++ b/libarchive/pkg.yaml
@@ -5,7 +5,7 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://www.libarchive.org/downloads/libarchive-{{ .libarchive_version }}.tar.xz
+      - url: https://github.com/libarchive/libarchive/releases/download/v{{ .libarchive_version }}/libarchive-{{ .libarchive_version }}.tar.xz
         destination: libarchive.tar.xz
         sha256: "{{ .libarchive_sha256 }}"
         sha512: "{{ .libarchive_sha512 }}"


### PR DESCRIPTION
Preserve System.map, so that we can use that to verify that module set and the kernel don't have unresolved symbols.