### PR TITLE
feat: bump kernel to 6.18.29

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -98,9 +98,9 @@ vars:
   kspp_sha512: 82dae1debbe94a3f82766a8cdbfe59ff8698d433175803458499b76c50b47b89e9280b677a9f16b2a44711badd6f4001aba951a41722a74dd51c03a18b8b9219
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 6.18.28
-  linux_sha256: f360789483586cf8a20b4ab2bffe76ead6b62c0db1eeb0d917294456c4d77b74
-  linux_sha512: 5acc1a97ae0bca7aeb7fcac04fd3b7bafea5ff976dfe5d42c7015e084d9ee3104c3945880846dfb185a1010d0bad8c7a229b23febdef44306d19fb494a03b1a6
+  linux_version: 6.18.29
+  linux_sha256: c33ea75b1f3bc5fccab836790cd3684eab7057ff383464b5efd8a68ba622a83c
+  linux_sha512: 2363ec5ca76b85140c8d0ce32b64215a6c780e901594df1ddbc3b080cfda71c60e0beea5f246f52f59c0b7ad32d446c31d27e8f673cf5ed1e242809ee343e851
 
   # renovate: datasource=git-tags extractVersion=^libaio-(?<version>.*)$ depName=https://pagure.io/libaio.git
   libaio_version: 0.3.113

--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 6.18.28 Kernel Configuration
+# Linux/x86 6.18.29 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="clang version 22.1.2"
 CONFIG_GCC_VERSION=0

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.18.28 Kernel Configuration
+# Linux/arm64 6.18.29 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="clang version 22.1.2"
 CONFIG_GCC_VERSION=0


### PR DESCRIPTION
Bump kernel to 6.18.29


(cherry picked from commit d0c548047d258834d43c64159edb3d079cbefea4)