### PR TITLE
chore: update containerd to v2.2.4

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -13,10 +13,10 @@ vars:
   cni_sha512: 8383a9f3fca75e978b84035609668f139e34cac7c5c1547c2913b6893754c3a0ec55acef73fd8e362094ca022359f2fa6c54dec55bada6b8fb8db7e9d7c889ea
 
   # renovate: datasource=github-tags depName=containerd/containerd
-  containerd_version: v2.1.7
-  containerd_ref: c74fd8780002eb26bd5940ae339d690d891221c2
-  containerd_sha256: 33f5d631854546fbbdb273d189756ece62a21c05f0acb92c8a7e23e7d259daf6
-  containerd_sha512: bb5f8d03b269005bea54fabd603be1909496da8f4148c8cb2b720ac68cf5b205f81c0af3fdc8109ec661d3a65c117a94001910b8839540999e1e22430b94ef83
+  containerd_version: v2.2.4
+  containerd_ref: 193637f7ee8ae5f5aa5248f49e7baa3e6164966e
+  containerd_sha256: f73a4580a869426120bc99bcd812ac723701a8c934549f70c8a6067e30e1458d
+  containerd_sha512: 99255b13fb113b9ba2ec9ab83c4cae5728c672fcd67c8dce915eda4a56a4a5766dd297cf35a17920001a995ed6924131bbc85b9a48d78d86939c987748345ce7
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/cryptsetup/cryptsetup.git
   cryptsetup_version: 2.8.1


### PR DESCRIPTION
Update containerd: `v2.1.7` -> `v2.2.4`

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
