### PR TITLE
feat: update containerd to 2.3.1

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -14,10 +14,10 @@ vars:
   cni_sha512: 5811fb14786f1f9d9e40741ce337449ce329e14e04213bc660102eb470150f24026e59caec480572e37d0e3e6e6518737f3cc7ac462c47034d0737283ec532f9
 
   # renovate: datasource=github-tags depName=containerd/containerd
-  containerd_version: v2.3.0
-  containerd_ref: 2976f38ccbfcda5ef1364d63d60b0a304e4bf94a
-  containerd_sha256: 915ef1d9fab5fbd8e3726bfb80c901fd87aa25e938bed5194df132853036ed58
-  containerd_sha512: d7c26fd6fd46dd4380652a501b16a8afc478a66f287825df5224048894f02465770d5e89e52ea7366c1ea4013547be94af066dac33419320257bdd4761a48160
+  containerd_version: v2.3.1
+  containerd_ref: 64b425cf570b3b8dd1d4cc46da7c1fce65c6651a
+  containerd_sha256: 9de4cb8bfb27964a8ffd95e35326b7279ea2e2a6506da16c2533d3f523f12c11
+  containerd_sha512: a0dbb73c73267205a5e880afa370371b84cbb45d3c64071b9e6f9b8124377c0833a20799e4492df0636781f0af7016703475e96d4750ce235f9706c9d90f5191
 
   # renovate: datasource=github-tags depName=kdave/btrfs-progs
   btrfsprogs_version: 6.19.1


### PR DESCRIPTION
See https://redirect.github.com/containerd/containerd/releases/tag/v2.3.1