### PR TITLE
feat: add amneziawg kernel module + awg userspace package

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -282,6 +282,14 @@ vars:
   zfs_version: 2.4.2
   zfs_sha256: 7e260d0e6af295bea4c5e241cac0a1aef07b58d8dd8035f7898ade3b1bbec78f
   zfs_sha512: 833cc076ae65a4ac6acc27c6c62f60568af0c291b9a1091a1835543861a291606e314b09ca14558cbed11239bb613e3f1f7f9e7fedeea6635e27aacde8c22378
+  # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=amnezia-vpn/amneziawg-linux-kernel-module
+  amneziawg_version: 1.0.20260329
+  amneziawg_sha256: 9bc6779711559a298f7c8ec1f5ca33ea151166f409b748cd761866a05b4bd39f
+  amneziawg_sha512: 7ceda29b2280ee101fdda5428e5136f823032cb6e663f23816d43ded7c0199cfcc3c3a301cadb5817a6d94650a49e13fd9e0dcb74b3ba8e5fbb2df13fc87a233
+  # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=amnezia-vpn/amneziawg-tools
+  amneziawg_tools_version: 1.0.20260223
+  amneziawg_tools_sha256: ab09cfafe6c1e9a6260964a8ba5cb2d657cc23862eb0c29253305e532ac40a16
+  amneziawg_tools_sha512: 591afaef659e26be16c8d883da8d8ff026f855f60c9887440b566ef18b9948ca57754673d833f27e77d8c05f7e354f37b49adc9f5467334eeb7eda7165960c54
 
   # NOTE: v4 requires autoconf-archive
   # renovate: datasource=git-tags depName=https://gitlab.com/apparmor/apparmor.git

--- a/amneziawg/pkg.yaml
+++ b/amneziawg/pkg.yaml
@@ -1,0 +1,64 @@
+name: amneziawg-pkg
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+  - stage: kernel-build
+  - image: "{{ .LLVM_IMAGE }}:{{ .TOOLS_REV }}"
+steps:
+  - sources:
+      - url: https://github.com/amnezia-vpn/amneziawg-linux-kernel-module/archive/refs/tags/v{{ .amneziawg_version }}.tar.gz
+        destination: amneziawg.tar.gz
+        sha256: "{{ .amneziawg_sha256 }}"
+        sha512: "{{ .amneziawg_sha512 }}"
+      - url: https://github.com/amnezia-vpn/amneziawg-tools/archive/refs/tags/v{{ .amneziawg_tools_version }}.tar.gz
+        destination: amneziawg-tools.tar.gz
+        sha256: "{{ .amneziawg_tools_sha256 }}"
+        sha512: "{{ .amneziawg_tools_sha512 }}"
+    env:
+      LLVM: 1
+    prepare:
+      - |
+        mkdir -p kmod tools
+        tar -xzf amneziawg.tar.gz --strip-components=1 -C kmod
+        tar -xzf amneziawg-tools.tar.gz --strip-components=1 -C tools
+  - network: none
+    env:
+      LLVM: 1
+    build:
+      # Out-of-tree kernel module against the kernel-build stage.
+      - |
+        make -j $(nproc) -C kmod/src KERNELDIR=/src LLVM=1
+      # Statically-linked `awg` userspace control tool (no runtime libs, so it
+      # drops straight into a scratch extension rootfs). Upstream's Makefile
+      # builds the binary as `wg`; it's renamed to `awg` on install.
+      - |
+        make -j $(nproc) -C tools/src CC="cc -static" WITH_BASHCOMPLETION=no WITH_WGQUICK=no WITH_SYSTEMDUNITS=no
+  - network: none
+    install:
+      # Module: install + sign with the kernel build's signing key.
+      - |
+        KREL=$(cat /src/include/config/kernel.release)
+        mkdir -p /rootfs/usr/lib/modules/${KREL}/
+        cp /src/modules.order /rootfs/usr/lib/modules/${KREL}/
+        cp /src/modules.builtin /rootfs/usr/lib/modules/${KREL}/
+        cp /src/modules.builtin.modinfo /rootfs/usr/lib/modules/${KREL}/
+        make -C /src M=$(pwd)/kmod/src modules_install \
+          DESTDIR=/rootfs \
+          INSTALL_MOD_PATH=/rootfs/usr \
+          INSTALL_MOD_DIR=extras \
+          INSTALL_MOD_STRIP=1 \
+          CONFIG_MODULE_SIG_ALL=y
+      # awg userspace tool.
+      - |
+        mkdir -p /rootfs/usr/bin
+        cp tools/src/wg /rootfs/usr/bin/awg
+        chmod 0755 /rootfs/usr/bin/awg
+    test:
+      - |
+        find /rootfs/usr/lib/modules -name '*.ko' -exec grep -FL '~Module signature appended~' {} \+
+      - |
+        fhs-validator /rootfs
+finalize:
+  - from: /rootfs
+    to: /


### PR DESCRIPTION
## What

Adds `amneziawg-pkg`, building:

- the [AmneziaWG](https://github.com/amnezia-vpn/amneziawg-linux-kernel-module) out-of-tree **kernel module**, built against the `kernel-build` stage and signed with the kernel's module-signing key (`CONFIG_MODULE_SIG_ALL=y`) — structure mirrors `drbd-pkg` / `zfs-pkg`;
- a statically-linked **`awg`** userspace control tool from [amneziawg-tools](https://github.com/amnezia-vpn/amneziawg-tools) (no runtime libs, so it drops straight into a `scratch` extension rootfs).

## Why

AmneziaWG is a WireGuard fork that adds traffic-shape obfuscation (junk packets, header transformation) so the on-wire format isn't trivially DPI-fingerprintable. Several carriers/ISPs across multiple jurisdictions selectively impair or throttle standard WireGuard; as Talos clusters increasingly span multiple providers/continents, a DPI-resistant inter-node underlay is a practical operational need.

This is the kernel-side package. Service packaging + boot-time interface bring-up live in the companion **siderolabs/extensions#1103** (`network/amneziawg`) — same split as drbd/zfs (module here, service there).

### Why a kernel module (and not only userspace `amneziawg-go`)?

A userspace-only path already exists in siderolabs/extensions#1004 (`amneziawg-go`). The two are complementary, but the kernel module is the production-appropriate default for Talos:

- Talos ships **no userspace WireGuard** in the base — a userspace approach means bundling and supervising a Go daemon per node, with extra user/kernel copies and context switches and lower throughput. The kernel module keeps the datapath **in-kernel at line rate**, which matters when the mesh carries etcd peering + Cilium pod-to-pod traffic.
- It slots into Talos's **existing kernel-module-extension model** (the same mechanism as other in-tree network modules), so there's no new supervision surface.
- AmneziaWG's obfuscation parameters (`Jc`/`Jmin`/`Jmax`/`S1`/`S2`/`H1..H4`) are exposed over the **same netlink-genl interface** as the in-kernel WireGuard device, so the userspace tooling stays minimal (just the small `awg` control binary for `awg setconf`).

## Details

- module source `v1.0.20260329`, tools `v1.0.20260223`; both pinned in `Pkgfile` `vars:` with renovate annotations (same convention as drbd/zfs).
- module build: `make -C kmod/src KERNELDIR=/src LLVM=1` (kernel built with clang); install + sign mirrors `drbd-pkg`.
- `awg`: `make -C tools/src CC="cc -static" WITH_WGQUICK=no` → `/usr/bin/awg`.
- `test` asserts the `.ko` is signed and runs `fhs-validator`.

## Validation

Validated end-to-end on a live **multi-node Talos v1.13.3 cluster**: 3 control-plane nodes meshed over AmneziaWG with **etcd quorum** and **Cilium pod-to-pod traffic** flowing through the mesh. Built from a custom installer/imager with this module (custom kernel from this repo's `release-1.13`), signed and loaded under `module.sig_enforce=1` + SecureBoot (PK/KEK/db enrolled), and brought up at boot by the companion extension's service before kubelet/etcd.

I couldn't run the `pkg.yaml` through this repo's full CI / kernel-build matrix locally, so the exact module-build/sign invocation or the arm64 leg may need a small tweak — happy to iterate.

## CI note

All commit-conformance checks pass except `conform/commit/gpg` / `conform/commit/gpg-identity`, which require a signature from a key belonging to a `siderolabs` org member and so can't go green on an external fork — happy for a maintainer to re-sign the commit at merge time (the commit is otherwise DCO-signed). Let me know if you'd prefer I handle it differently.

## Open questions

1. Module + userspace `awg` in one pkg OK, or do you prefer the userspace split into the extension (like `zfs-tools`)?
2. arm64 — builds the same way; I only have amd64 to verify on.
3. Ordering vs the extensions PR — happy to land this first.
