### PR TITLE
feat: enable USB hiddev for apcupsd support

### DIFF
--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -5462,7 +5462,7 @@ CONFIG_I2C_HID=m
 #
 CONFIG_USB_HID=m
 # CONFIG_HID_PID is not set
-# CONFIG_USB_HIDDEV is not set
+CONFIG_USB_HIDDEV=y
 
 #
 # USB HID Boot Protocol drivers

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -6560,7 +6560,7 @@ CONFIG_I2C_HID=m
 #
 CONFIG_USB_HID=m
 # CONFIG_HID_PID is not set
-# CONFIG_USB_HIDDEV is not set
+CONFIG_USB_HIDDEV=y
 
 #
 # USB HID Boot Protocol drivers


### PR DESCRIPTION
apcupsd's Linux USB driver uses the hiddev interface for some APC UPS devices connected as USB HID class devices, so enable CONFIG_USB_HIDDEV.

https://sourceforge.net/p/apcupsd/svn/HEAD/tree/branches/Branch-3_14/src/drivers/usb/linux/linux-usb.c
