### PR TITLE
feat: bump dependencies

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@ format: v1alpha2
 vars:
   TOOLCHAIN_MUSL_IMAGE: ghcr.io/siderolabs/toolchain-musl:v1.14.0-alpha.0-10-gef6c712
   TOOLS_PREFIX: ghcr.io/siderolabs/
-  TOOLS_REV: v1.14.0-alpha.0-14-g42c59b9
+  TOOLS_REV: v1.14.0-alpha.0-15-gb88d99c
   LLVM_IMAGE: ghcr.io/siderolabs/llvm
 
   # renovate: datasource=github-releases depName=containernetworking/plugins

--- a/Pkgfile
+++ b/Pkgfile
@@ -103,9 +103,9 @@ vars:
   kspp_sha512: 5084799b38dcd4b949fd55157740c3cc5d276df560c2f8cccca6e18684ca8dedd9f0ad5159b30f655a913865dcbd41459a0a8af15610456a7a9e3a7080a35424
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 6.18.34
-  linux_sha256: 640c4732fb42842166db97e032c1fe7e5ff72c85a8982c75b40f74be3555d760
-  linux_sha512: 0693f39aaf414cc4c5e1928b4373e24b25797fd3578a22f25d1be2ab5a318dfb42d374dc70c388e9929e8b9795bc397b9d7a281817c6509057ae54047a961582
+  linux_version: 6.18.35
+  linux_sha256: f78602932219125e211c5f5bfd84edcfd4ec5ce88fc944f8248413f665bef236
+  linux_sha512: 8888a1f908473ea91e943a9c61cff956939709b0ded2d2e5cc26f377d1799ce5ba4d247c522508d13c3769ad90f804a8ef423fa782c10ae8e7ce9e7504bd8871
 
   # renovate: datasource=git-tags extractVersion=^libaio-(?<version>.*)$ depName=https://pagure.io/libaio.git
   libaio_version: 0.3.113

--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 6.18.34 Kernel Configuration
+# Linux/x86 6.18.35 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="clang version 22.1.6"
 CONFIG_GCC_VERSION=0

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.18.34 Kernel Configuration
+# Linux/arm64 6.18.35 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="clang version 22.1.6"
 CONFIG_GCC_VERSION=0


### PR DESCRIPTION
* [feat: bump kernel to 6.18.35](https://github.com/siderolabs/pkgs/commit/cb713ae48611f7c8ae31a08232cda482f2d6bfc1)
* [feat: bump OpenSSL to 3.6.3](https://github.com/siderolabs/pkgs/commit/d213ff5e7d88436fd4082fb4defdf4c17c23a8ac)