### PR TITLE
fix: correct finalize destination path

### DIFF
--- a/mdadm/pkg.yaml
+++ b/mdadm/pkg.yaml
@@ -42,4 +42,4 @@ steps:
         - GPL-2.0-or-later
 finalize:
   - from: /rootfs
-    to: /rootfs
+    to: /


### PR DESCRIPTION
Installation should target root filesystem (/), not subdirectory.
Fixes package structure for proper mdadm binary placement.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
