### PR TITLE
feat: build runc with libpathrs (only amd64)

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,10 +3,11 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_MUSL_IMAGE: ghcr.io/siderolabs/toolchain-musl:v1.14.0-alpha.0-11-g8f8a35d
+  TOOLCHAIN_MUSL_IMAGE: ghcr.io/siderolabs/toolchain-musl:v1.14.0-alpha.0-12-g4012a7d
   TOOLS_PREFIX: ghcr.io/siderolabs/
-  TOOLS_REV: v1.14.0-alpha.0-18-g878f1db
+  TOOLS_REV: v1.14.0-alpha.0-19-g5326524
   LLVM_IMAGE: ghcr.io/siderolabs/llvm
+  RUSTC_IMAGE: ghcr.io/siderolabs/rustc:v1.14.0-alpha.0
 
   # renovate: datasource=github-releases depName=containernetworking/plugins
   cni_version: v1.9.1
@@ -171,6 +172,12 @@ vars:
   xz_version: 5.8.3
   xz_sha256: fff1ffcf2b0da84d308a14de513a1aa23d4e9aa3464d17e64b9714bfdd0bbfb6
   xz_sha512: c288f436b211031ca122e9169d85403d4ab8b0500a6542b2d9ba101587e04a4358ab5509f5d15cc7899f1ab3e0118567866ca0508f880007b4af802dedd7068d
+
+  # NOTE: keep in sync with the libpathrs version required by runc: https://github.com/opencontainers/runc/blob/release-1.5/script/build-libpathrs.sh
+  # renovate: datasource=github-releases depName=cyphar/libpathrs
+  libpathrs_version: v0.2.5
+  libpathrs_sha256: f8f4a9419eb839cd5decbd120b65f0495bf6eac07155477fe39a8c2a23da589d
+  libpathrs_sha512: 009a6aa91d4ef5ccae011f39def4cf7ffc626fd7def9e9cbcf7c827d813215811719c44674e68192d3f4770c7968f2e7de7c13b27c7e53807f0aa0f4ba5c428f
 
   # renovate: datasource=github-releases extractVersion=^popt-(?<version>.*)-release$ depName=rpm-software-management/popt
   libpopt_version: 1.19

--- a/libpathrs/pkg.yaml
+++ b/libpathrs/pkg.yaml
@@ -1,0 +1,86 @@
+name: libpathrs
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+  # CA certificates so cargo can verify TLS when fetching crates from crates.io.
+  - stage: ca-certificates
+  # rustc is dynamically linked against LLVM's shared library (libLLVM.so),
+  # which ships in the llvm image; without it `rustc -vV` fails to load.
+  - image: "{{ .LLVM_IMAGE }}:{{ .TOOLS_REV }}"
+  - image: "{{ .RUSTC_IMAGE }}"
+steps:
+  - sources:
+      - url: https://github.com/cyphar/libpathrs/releases/download/{{ .libpathrs_version }}/libpathrs-{{ .libpathrs_version | trimPrefix "v" }}.tar.xz
+        destination: libpathrs.tar.xz
+        sha256: "{{ .libpathrs_sha256 }}"
+        sha512: "{{ .libpathrs_sha512 }}"
+  - network: default
+    env:
+      # cargo/libcurl needs an explicit CA bundle; ca-certificates ships it at a
+      # non-standard path (no .crt suffix) that curl won't auto-discover.
+      CARGO_HTTP_CAINFO: /etc/ssl/certs/ca-certificates
+      SSL_CERT_FILE: /etc/ssl/certs/ca-certificates
+    prepare:
+      - |
+        tar -xJf libpathrs.tar.xz --strip-components=1
+
+        # Drop the cargo workspace members (contrib/fake-enosys, e2e-tests): they
+        # are dev/test crates we don't build, and cargo would otherwise try to
+        # build and resolve their dependencies too. The [workspace] table is the
+        # last block in Cargo.toml, so we can strip it to EOF.
+        sed -i '/^\[workspace\]/,$d' Cargo.toml
+
+        # Download the crate dependencies while network is available; the build
+        # step below runs with `network: none` and cargo `--offline`.
+        cargo fetch
+  - network: none
+    build:
+      - |
+        # Build only the C static library (staticlib). We intentionally do not
+        # run `make release` because that also builds the cdylib (libpathrs.so),
+        # which links with lld (`-fuse-ld=lld`) and produces a shared object we
+        # don't ship. runc links libpathrs statically, so the .a is all we need.
+        #
+        # This mirrors the staticlib recipe from libpathrs' Makefile:
+        #   * --features=capi exposes the C API,
+        #   * RUSTFLAGS="-C panic=abort" avoids the unwinder (no libgcc_s dep),
+        #   * with-crate-type.sh flips [lib] crate-type to staticlib (MSRV<1.64).
+        LIBPATHRS_CAPI_BUILDMODE=staticlib \
+          ./hack/with-crate-type.sh --crate-type=staticlib \
+          env RUSTFLAGS="-C panic=abort" \
+          cargo build --features=capi --release --offline
+    install:
+      - |
+        # install.sh stages libpathrs.a + pathrs.h + a pathrs.pc with the real
+        # install paths baked in. --disable-dynamic skips the (unbuilt) .so.
+        ./install.sh \
+          --prefix=/usr \
+          --libdir=/usr/lib \
+          --enable-static \
+          --disable-dynamic \
+          DESTDIR=/rootfs
+    test:
+      - |
+        set -e
+        # static library, header and pkg-config metadata must be present, and
+        # no shared object must be shipped
+        test -f /rootfs/usr/lib/libpathrs.a
+        test -f /rootfs/usr/include/pathrs.h
+        test -f /rootfs/usr/lib/pkgconfig/pathrs.pc
+        ! ls /rootfs/usr/lib/libpathrs.so* 2>/dev/null
+        # pkg-config resolves the module
+        PKG_CONFIG_PATH=/rootfs/usr/lib/pkgconfig pkg-config --exists pathrs
+      - |
+        fhs-validator /rootfs
+    sbom:
+      outputPath: /rootfs/usr/share/spdx/libpathrs.spdx.json
+      version: "{{ .libpathrs_version }}"
+      cpes:
+        - cpe:2.3:a:cyphar:libpathrs:{{ .libpathrs_version }}:*:*:*:*:*:*:*
+      licenses:
+        - MPL-2.0
+        - LGPL-3.0-or-later
+finalize:
+  - from: /rootfs
+    to: /

--- a/runc/pkg.yaml
+++ b/runc/pkg.yaml
@@ -4,6 +4,13 @@ shell: /bin/bash
 dependencies:
   - stage: base
   - stage: libseccomp
+  # libpathrs is built (and linked into runc) only on x86_64. The aarch64 rustc
+  # image can't build it yet (a musl TLS bug crashes the cross-built aarch64
+  # rustc), so arm64 runc uses the pure-Go pathrs-lite fallback instead (see the
+  # RUNC_BUILDTAGS="-libpathrs" in the build step).
+  # {{ if ne .ARCH "aarch64" }} YAML comment, but the Go template is evaluated by bldr
+  - stage: libpathrs
+  # {{ end }}
 steps:
   - sources:
       # sync with commit in build
@@ -25,16 +32,20 @@ steps:
 
         ldflags="-w -s -buildid="
 
-        # runc 1.5 enables the `libpathrs` build tag by default, which links the
-        # external Rust libpathrs C library (via pkg-config) for path safety. We
-        # don't have a libpathrs/Rust toolchain, so we drop the tag with
-        # RUNC_BUILDTAGS="-libpathrs"; runc falls back to the pure-Go pathrs-lite.
+        # runc 1.5's default build tags (seccomp urfave_cli_no_docs libpathrs)
+        # link the Rust libpathrs C library (via `pkg-config: pathrs`) for
+        # hardened, race-free path resolution. On x86_64 we build libpathrs as a
+        # static library in the `libpathrs` stage (its libpathrs.a/pathrs.h/
+        # pathrs.pc land on PKG_CONFIG_PATH) and keep the default tags.
+        #
+        # On aarch64 the rustc image can't build libpathrs yet (a musl TLS bug
+        # crashes the cross-built aarch64 rustc), so we drop the tag with
+        # RUNC_BUILDTAGS="-libpathrs" and runc uses its pure-Go pathrs-lite
+        # fallback. Switch arm64 to libpathrs once the toolchain is fixed.
         #
         # https://github.com/opencontainers/runc#build-tags
-        # 
-        # We will switch to libpathrs after https://github.com/siderolabs/toolchain/issues/206
 
-        make COMMIT={{ .runc_ref }} RUNC_BUILDTAGS="-libpathrs" EXTRA_FLAGS="-a" EXTRA_LDFLAGS="${ldflags}" static
+        make COMMIT={{ .runc_ref }} {{ if eq .ARCH "aarch64" }}RUNC_BUILDTAGS="-libpathrs" {{ end }}EXTRA_FLAGS="-a" EXTRA_LDFLAGS="${ldflags}" static
     install:
       - |
         cd runc
@@ -49,12 +60,14 @@ steps:
         runc=/rootfs/usr/bin/runc
 
         # binary runs and reports the expected version and embedded commit, and
-        # (being built with the seccomp tag) prints a libseccomp line
+        # (built with the seccomp tag) prints a libseccomp line; on x86_64 it also
+        # prints a libpathrs line (libpathrs is not linked on aarch64).
         version="$("${runc}" --version)"
         echo "${version}"
         echo "${version}" | grep -q '{{ .runc_version | trimPrefix "v" }}'
         echo "${version}" | grep -q '{{ .runc_ref }}'
         echo "${version}" | grep -q '^libseccomp:'
+        {{ if ne .ARCH "aarch64" }}echo "${version}" | grep -q '^libpathrs:'{{ end }}
 
         # `features` reports seccomp support (also exercises more of the binary)
         "${runc}" features | grep -q '"seccomp"'


### PR DESCRIPTION
Use newly built rustc to build runc with libpathrs.

The arm64 rustc compiler seems to be still broken due to issue with
libmusl/TLS initialization.