### PR TITLE
feat: enable devmapper plugin in containerd build

### DIFF
--- a/containerd/pkg.yaml
+++ b/containerd/pkg.yaml
@@ -13,7 +13,7 @@ steps:
     env:
       PKG_CONFIG_PATH: /usr/lib/pkgconfig
       CC: gcc
-      BUILDTAGS: 'no_aufs no_btrfs no_devmapper no_systemd no_zfs'
+      BUILDTAGS: 'no_aufs no_btrfs no_systemd no_zfs'
     prepare:
       - |
         tar -xzf containerd.tar.gz --strip-components=1
@@ -31,6 +31,8 @@ steps:
     test:
       - |
         fhs-validator /rootfs
+      - |
+        /rootfs/usr/bin/containerd --version | grep -Fq "{{ .containerd_version }}"
     sbom:
       outputPath: /rootfs/usr/share/spdx/containerd.spdx.json
       version: {{ .containerd_version }}


### PR DESCRIPTION
Fixes https://github.com/siderolabs/talos/issues/13704

The plugin doesn't load if not configured:

```
172.20.0.5: {"id":"io.containerd.snapshotter.v1.devmapper","level":"info","msg":"loading plugin","time":"2026-07-13T12:41:35.398197257Z","type":"io.containerd.snapshotter.v1"}
172.20.0.5: {"error":"devmapper not configured: skip plugin","id":"io.containerd.snapshotter.v1.devmapper","level":"info","msg":"skip loading plugin","time":"2026-07-13T12:41:35.398209891Z","type":"io.containerd.snapshotter.v1"}
```