### PR TITLE
chore: bump bldr to v0.6.1

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -1,4 +1,4 @@
-# syntax = ghcr.io/siderolabs/bldr:v0.6.0
+# syntax = ghcr.io/siderolabs/bldr:v0.6.1
 
 format: v1alpha2
 


### PR DESCRIPTION
Makefile bldr version was already bumped in 3f09c0c8d9d5522d0f78a86df98971ae7913afea