### PR TITLE
chore: (1.12) bldr back to v0.5.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ SOURCE_DATE_EPOCH := $(shell git log $(INITIAL_COMMIT_SHA) --pretty=%ct)
 
 # sync bldr image with pkgfile
 
-BLDR_RELEASE := v0.6.1
+BLDR_RELEASE := v0.5.6
 BLDR_IMAGE := ghcr.io/siderolabs/bldr:$(BLDR_RELEASE)
 BLDR := docker run --rm --user $(shell id -u):$(shell id -g) --volume $(PWD):/src --entrypoint=/bldr $(BLDR_IMAGE) --root=/src
 
@@ -280,4 +280,3 @@ renovate-local:  ## runs renovate locally to check syntax and test configuration
 		-e RENOVATE_PLATFORM=local \
 		-e RENOVATE_DRY_RUN=full \
 	renovate/renovate
-

--- a/Pkgfile
+++ b/Pkgfile
@@ -1,11 +1,11 @@
-# syntax = ghcr.io/siderolabs/bldr:v0.6.1
+# syntax = ghcr.io/siderolabs/bldr:v0.5.6
 
 format: v1alpha2
 
 vars:
   TOOLCHAIN_MUSL_IMAGE: ghcr.io/siderolabs/toolchain-musl:v1.12.0-14-g82698c2
   TOOLS_PREFIX: ghcr.io/siderolabs/
-  TOOLS_REV: v1.12.0-19-gb77038c
+  TOOLS_REV: v1.12.0-20-g7a5d6da
 
   # renovate: datasource=github-releases depName=containernetworking/plugins
   cni_version: v1.9.0


### PR DESCRIPTION
The `bldr` version shouldn't be upgraded for backport branches.

Bumps `tools` to use image based on bldr `v0.5.6`.
https://github.com/siderolabs/tools/commit/7a5d6da4b362734a9e15d4174e323397bf204e9f