### PR TITLE
backports: for Talos v1.13.9

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -93,9 +93,9 @@ vars:
   ipxe_sha512: 8c103d3d9debe277333d8c3e0d935d76968a197aad6891e4b6491dc6378555ba359249e04381e6895f68296898dbdc2cf022b43e0b2108b779c88fe769fee4ba
 
   # renovate: datasource=git-refs versioning=git depName=https://github.com/a13xp0p0v/kernel-hardening-checker.git
-  kspp_ref: e354f6ab5279f9cfa8bfdd7e13e454ccf69209f9
-  kspp_sha256: 640b25473f86557d082f680b0f57653a69f4146e97825673bf582f9a4c8b7739
-  kspp_sha512: 82dae1debbe94a3f82766a8cdbfe59ff8698d433175803458499b76c50b47b89e9280b677a9f16b2a44711badd6f4001aba951a41722a74dd51c03a18b8b9219
+  kspp_ref: 5b77d399781cb5aebf6e419d8f55e9813c6874f4
+  kspp_sha256: 68ccfb39a6d78a94b2baa1dfad9580d86350fb81ce3b21ed639406530a3dd3c4
+  kspp_sha512: 085366adc1ee4f1361354f23355594aa1b27c38dac36038a255b7d84fb21860589cb846c48460b2f5b41045e9073b4dba7d3b2d4e20dc1e1d5ed6944c03bc56c
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
   linux_version: 6.18.42
@@ -108,9 +108,9 @@ vars:
   libaio_sha512: 65c30a102433bf8386581b03fc706d84bd341be249fbdee11a032b237a7b239e8c27413504fef15e2797b1acd67f752526637005889590ecb380e2e120ab0b71
 
   # renovate: datasource=github-releases extractVersion=^v(?<version>.*)$ depName=libarchive/libarchive
-  libarchive_version: 3.8.7
-  libarchive_sha256: d3a8ba457ae25c27c84fd2830a2efdcc5b1d40bf585d4eb0d35f47e99e5d4774
-  libarchive_sha512: 0673accf9ac6ede2d1c7e68419d00898f35e43130c5ec6b5fcdea85d174d8b0cc56d1d609bd5533370c3cca5f6ddd5b59fc153f2dadea2b4b5c2421a574ea352
+  libarchive_version: 3.8.9
+  libarchive_sha256: 888c934f9d95648ecb9163dc8e23ab80a476ecb81a8f1154704a227b5b676dde
+  libarchive_sha512: f37425417a9e3fdc194a2b892137452ddba6601c69e822598692d4d776c573a90e70aac4598d47c915615facc45d0c83fc46c24856ddf04afd7494b63bb9f137
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.savannah.gnu.org/attr.git
   libattr_version: 2.5.2
@@ -204,19 +204,18 @@ vars:
   mtools_sha512: 30e75cd85916b7c5b81e667fec1e47f19c024a988a643e8fa8ddd4a20b96c58d29c528d033548f9a603119835e414ea6fc671b3dafa08f50b9192991276d2447
 
   # renovate: datasource=custom.nvidia-driver-lts depName=nvidia-driver-lts
-  nvidia_driver_lts_version: 580.173.02
-  nvidia_driver_lts_arm64_sha256: 5b79c3c161089776dcda061f1a2a7aefd0377c99d846682249e65f6333b1f357
-  nvidia_driver_lts_arm64_sha512: 8a00c3182ef2310b403b67852918fb38cdd89bf92846d627c3bc77c7108c230262d794388ab75bbedab8f0f0a9b8e43cb26dabe5267e441d9423b64ae71f8a0f
-  nvidia_driver_lts_amd64_sha256: 18e19ffca091473ac5e81c63436ef2911dd2485be4b8770c2ee124ece3a3a5f7
-  nvidia_driver_lts_amd64_sha512: b10f678dc08812a5dfa45dfb041107062e0c61d087b2637ac1d46bda36f5ddf70025a274594cd4ddda9e9961c13e3cb79fcfd3b8f35cb95de09fee40c0b1b928
+  nvidia_driver_lts_version: 580.178.04
+  nvidia_driver_lts_arm64_sha256: 8e55dfbe85b1aa9fbd2e323ed203470ebf6001f614d1f8cb4fa0671ea979a557
+  nvidia_driver_lts_arm64_sha512: 05fac615240326349e2cc3c999f1a0d2181a0cc88ece6f28b964a16ef70f9d23cc7b4c76cb478a4345f0587de5e9f43a746f7070a8babee91fb9803a9e938fe2
+  nvidia_driver_lts_amd64_sha256: 269bfbc57d176ea21eede622a5c638c84354ed70ffcc3d092679ce10d3fef409
+  nvidia_driver_lts_amd64_sha512: 4cab88f79734f32bbf3a2bdf988bb30585f15802063f9244b209c57735cf44cd8275f07886a919736a644166467db1f0ff6bcfe861ebd9c689d4833a0ccd2645
 
-  # NOTE: Use the version that's also available under fabricmanager at https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-x86_64/
-  # renovate: datasource=github-releases extractVersion=^\d+\.(?<version>\d+\.\d+)$ depName=nvidia/open-gpu-kernel-modules
-  nvidia_driver_production_version: 595.71.05
-  nvidia_driver_production_arm64_sha256: 9f6df120c3e89f9cd54693b86c5fd54815890b564ad412969b9787e64b3a9ab4
-  nvidia_driver_production_arm64_sha512: 5607de521ca8fd416beaf704b924977803c25ed7b7f2816dcbdcf7c2a9117901f3bd7f9976925409778b0e8ac4c2750352031f33ca5ae50438411e4a6bb85779
-  nvidia_driver_production_amd64_sha256: 0cb57021f3858ca6565ac9eaf087aaa80d942ee8bfe8a220eec100e1489bc726
-  nvidia_driver_production_amd64_sha512: 5c4c2fb02f9b222da318668e0d5e93fd4fae81744e610490cb967e78cf61af8c7a8f5244f87d2967ba83b7be66b230d3b2bbafeff63790bcc77f4befdc089f99
+  # renovate: datasource=custom.nvidia-driver-production depName=nvidia-driver-production
+  nvidia_driver_production_version: 595.91.07
+  nvidia_driver_production_arm64_sha256: f0833df649a72c7cb675a179add564b8f8ed76c2e83faa9f1161f101d82b4fd3
+  nvidia_driver_production_arm64_sha512: 1ad7b483dd576ed49ade0427232b3259cccd030a3d8e937110ec3f850fcd84e7004a563761144f2420bf54e96686ab26e758e857e5b95e2ee80786856ab10607
+  nvidia_driver_production_amd64_sha256: 93e0487897e843be767a3d259dffea8ac32dffff846e83df8d3abbf30be754ae
+  nvidia_driver_production_amd64_sha512: a7cb28e9025218ea72bb868b3927f5ef08f790a9427de13db2678c3488dce689c6dde788f1162eeb809d99b43ee3b44ebe8688c63033a481d8973b328189d274
 
   # renovate: datasource=github-releases depName=vmware/open-vmdk
   open_vmdk_version: v0.3.13

--- a/Pkgfile
+++ b/Pkgfile
@@ -98,9 +98,9 @@ vars:
   kspp_sha512: 085366adc1ee4f1361354f23355594aa1b27c38dac36038a255b7d84fb21860589cb846c48460b2f5b41045e9073b4dba7d3b2d4e20dc1e1d5ed6944c03bc56c
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 6.18.42
-  linux_sha256: 35a8ef5e8fb44467e56a42b40c23c4c10a61d1e95ff8d738f285230e8bed63e7
-  linux_sha512: 2d4394be86ab046ed5e3366c77dc9bfca24dba0c042fd00ceabab2bb050652343313d03a3076020851dac4fde1f1e995a92f2b2d5910670b33be494caa8550e8
+  linux_version: 6.18.43
+  linux_sha256: a1aeb926c7c4a1564368200b1082e45bb958007682d804aff88abbc3a7a47b5d
+  linux_sha512: 77393001f6635e04c41bf28b8b4305b0c17339d7e70c753f73f45ada6758b3dd461cd975b3ad18123aa9e391f100b3bf8995d0b296db7cba05f9548adf636532
 
   # renovate: datasource=git-tags extractVersion=^libaio-(?<version>.*)$ depName=https://pagure.io/libaio.git
   libaio_version: 0.3.113

--- a/Pkgfile
+++ b/Pkgfile
@@ -184,9 +184,9 @@ vars:
   liburcu_sha512: 53c28821dabfc1e8803c4299f6a9e589c9949d0062dd8aaa4aabb6d77641dfbd2b2c035c50680991d9f228499c12b9b23469044726a6ffce5e84f21f17cabff3
 
   # renovate: datasource=git-tags depName=git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
-  linux_firmware_version: 20260622
-  linux_firmware_sha256: bb619f9a1e84eca686cfbe0ce1aab8946e42b3d674b3cd856843c1b6ca2d0032
-  linux_firmware_sha512: 6a508096dae9b9d8918aea9cb636205e58d08b1f31650900288541f9f330ee1cadeed30ba6cf10b810b5b18dc7b891967c2753342f8a127deb7bb10803c96e97
+  linux_firmware_version: 20260810
+  linux_firmware_sha256: b78dd0475df5aabafe1e515dc988b17de8c5f5afce16573453275f5f855a2cb2
+  linux_firmware_sha512: e287507d8b89d2f936e9313128ca35e86c101ff907e6b2255403d00e1f4bc0c48b45493a608fd61f160baea17d808c09d3c3d4cdacccf3a02826b8834c81989f
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://sourceware.org/git/lvm2.git
   lvm2_version: 2_03_39

--- a/Pkgfile
+++ b/Pkgfile
@@ -3,9 +3,9 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_MUSL_IMAGE: ghcr.io/siderolabs/toolchain-musl:v1.13.0-3-gc4993d7
+  TOOLCHAIN_MUSL_IMAGE: ghcr.io/siderolabs/toolchain-musl:v1.13.0-4-gd4c09bb
   TOOLS_PREFIX: ghcr.io/siderolabs/
-  TOOLS_REV: v1.13.0-8-gc2844e6
+  TOOLS_REV: v1.13.0-9-ga201d19
   LLVM_IMAGE: ghcr.io/siderolabs/llvm
 
   # renovate: datasource=github-releases depName=containernetworking/plugins
@@ -14,10 +14,10 @@ vars:
   cni_sha512: 5811fb14786f1f9d9e40741ce337449ce329e14e04213bc660102eb470150f24026e59caec480572e37d0e3e6e6518737f3cc7ac462c47034d0737283ec532f9
 
   # renovate: datasource=github-tags depName=containerd/containerd
-  containerd_version: v2.2.6
-  containerd_ref: 11ce9d5f3c68c941867e82890e93e815c1304f1b
-  containerd_sha256: 98992d2d2a652bcfaef0186d218c5ff254ba97ea1dd73425fe29be7036b3ac35
-  containerd_sha512: 42b5d0916a4d60413d582893904fd4313e2164fc78c3b7ac35806a258c4a3e5f4bdbcfb20ce9a5e924b5ad7215a2637bb5355126e3d88a115a8e248e0568fd81
+  containerd_version: v2.2.7
+  containerd_ref: 7835c8dfefceee63b1a4f9e84e015ddc8434fdc3
+  containerd_sha256: ea5954b342114fc07bbdcc1b4c0456459f6e807d2f53273559fcdb9030268a99
+  containerd_sha512: a4be7b1fc66e7a173cd141aabe257bf38f651d93376000ef07ecadb42e2c12babfef02c54487bc74352f89083949458b503728f8f32fb0453e6ab2459df73cd7
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/cryptsetup/cryptsetup.git
   cryptsetup_version: 2.8.6
@@ -50,10 +50,10 @@ vars:
   systemd_sha512: cb76b3a11b400fea94de2be74bcd9178b2e986c1965cbc19824114fe14fdd9b6aed43ae325cf5bc505efa1333adc71e131e0a8b54519e6741baa090392bf0a98
 
   # renovate: datasource=github-releases depName=flannel-io/cni-plugin
-  flannel_cni_version: v1.9.1-flannel1
+  flannel_cni_version: v1.9.1-flannel3
   flannel_cni_ref: 4c87e5d413198ceede07f8ef6f828357ebbd00c0
-  flannel_cni_sha256: 6401ccc2abe9c8e49a4f393d3c9c93f9d51287f7e7e7ac2658fc5ae0095d53d9
-  flannel_cni_sha512: 299ba3917588715a1bad3a36c23f96b2d29a23837711f7c9a6526f799078af16ba93a71d9c562c3cad305081f9ef21bddb764d7098e24dbd16e83856effdac39
+  flannel_cni_sha256: 23ed19c545ab63eabf899e70abd8a4ae161cf6a2700926259c6b59381d9df171
+  flannel_cni_sha512: 70db3836fa2595373fda10cede31b022a40da9857ea99f155e6cbb9f516849951b5177cf97526bc608b53aa4ddbd585b58320a757d6c6d2c1a2257a8b43a86d2
 
   # renovate: datasource=git-refs versioning=git depName=https://github.com/google/gasket-driver.git
   gasket_driver_ref: 5815ee3908a46a415aac616ac7b9aedcb98a504c

--- a/Pkgfile
+++ b/Pkgfile
@@ -93,14 +93,14 @@ vars:
   ipxe_sha512: 8c103d3d9debe277333d8c3e0d935d76968a197aad6891e4b6491dc6378555ba359249e04381e6895f68296898dbdc2cf022b43e0b2108b779c88fe769fee4ba
 
   # renovate: datasource=git-refs versioning=git depName=https://github.com/a13xp0p0v/kernel-hardening-checker.git
-  kspp_ref: 5b77d399781cb5aebf6e419d8f55e9813c6874f4
-  kspp_sha256: 68ccfb39a6d78a94b2baa1dfad9580d86350fb81ce3b21ed639406530a3dd3c4
-  kspp_sha512: 085366adc1ee4f1361354f23355594aa1b27c38dac36038a255b7d84fb21860589cb846c48460b2f5b41045e9073b4dba7d3b2d4e20dc1e1d5ed6944c03bc56c
+  kspp_ref: e354f6ab5279f9cfa8bfdd7e13e454ccf69209f9
+  kspp_sha256: 640b25473f86557d082f680b0f57653a69f4146e97825673bf582f9a4c8b7739
+  kspp_sha512: 82dae1debbe94a3f82766a8cdbfe59ff8698d433175803458499b76c50b47b89e9280b677a9f16b2a44711badd6f4001aba951a41722a74dd51c03a18b8b9219
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 6.18.43
-  linux_sha256: a1aeb926c7c4a1564368200b1082e45bb958007682d804aff88abbc3a7a47b5d
-  linux_sha512: 77393001f6635e04c41bf28b8b4305b0c17339d7e70c753f73f45ada6758b3dd461cd975b3ad18123aa9e391f100b3bf8995d0b296db7cba05f9548adf636532
+  linux_version: 6.18.44
+  linux_sha256: 0f72d938f06828e82c90405174fe572287db7bfe089e2fc46572a99a7f240d43
+  linux_sha512: cb710375eb0dccdb8ac49db46517556b9e6d56d7ed5430336158cc63b6104366672964737508819ef49de03c9a7a02079027f2271748c6677bc7c32944631589
 
   # renovate: datasource=git-tags extractVersion=^libaio-(?<version>.*)$ depName=https://pagure.io/libaio.git
   libaio_version: 0.3.113

--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 6.18.42 Kernel Configuration
+# Linux/x86 6.18.43 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="clang version 22.1.2"
 CONFIG_GCC_VERSION=0

--- a/kernel/build/config-amd64
+++ b/kernel/build/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 6.18.43 Kernel Configuration
+# Linux/x86 6.18.44 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="clang version 22.1.2"
 CONFIG_GCC_VERSION=0

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.18.42 Kernel Configuration
+# Linux/arm64 6.18.43 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="clang version 22.1.2"
 CONFIG_GCC_VERSION=0

--- a/kernel/build/config-arm64
+++ b/kernel/build/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.18.43 Kernel Configuration
+# Linux/arm64 6.18.44 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="clang version 22.1.2"
 CONFIG_GCC_VERSION=0


### PR DESCRIPTION
PRs backported:

* tools sync (Go 1.26.6), containerd, Flannel CNI update
* #1637 
* #1643 
* #1640 
* #1641 