### PR TITLE
chore: update OpenZFS to 2.4.4

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -296,9 +296,9 @@ vars:
   xfsprogs_sha512: 5c6e2a57a8f2e04a50cf5a085509a229f7a858a5807d85d807deeef1013d6dbbc1d701da4adb010dec5e251774b6b32e28496309bd11b4e6ebcbc09999f04cd5
 
   # renovate: datasource=github-tags extractVersion=^zfs-(?<version>.*)$ depName=openzfs/zfs
-  zfs_version: 2.4.3
-  zfs_sha256: 1f08f2d154f5189b5f1382848a32667b3d34066145b474c49cd3d41a5fba59a7
-  zfs_sha512: 343fbb19c0ca5f91254d216b6113fb8a7b028bdafc976ba9cb1ff6b7d3442a6a0fbf2cc4bde4f2fcc7cb7293cc17a1914664a943e5c798d261d00b22a0e56989
+  zfs_version: 2.4.4
+  zfs_sha256: 2a3c70d55a37cc71618a95a60e81ad66530201eb118d37741dc92efcf848c8b1
+  zfs_sha512: 8be81dedc0c0ec38728248151a33b8cbc78b042bc27a913279009bd735faa6149ad5b4a2db5811d25f4a03820dd398e14f59a4aec07f6bd4bc39405190c4e4ad
 
   # NOTE: v4 requires autoconf-archive
   # renovate: datasource=git-tags depName=https://gitlab.com/apparmor/apparmor.git


### PR DESCRIPTION
Release notes: https://github.com/openzfs/zfs/releases/tag/zfs-2.4.4