### PR TITLE
fix: update OpenSSL to 3.6.4

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@ format: v1alpha2
 vars:
   TOOLCHAIN_MUSL_IMAGE: ghcr.io/siderolabs/toolchain-musl:v1.15.0-alpha.0-3-g2f1a147
   TOOLS_PREFIX: ghcr.io/siderolabs/
-  TOOLS_REV: v1.15.0-alpha.0-3-ge033f2a
+  TOOLS_REV: v1.15.0-alpha.0-4-g35fab51
   LLVM_IMAGE: ghcr.io/siderolabs/llvm
   RUSTC_IMAGE: ghcr.io/siderolabs/rustc:v1.15.0-alpha.0
 


### PR DESCRIPTION
Update OpenSSL from 3.6.3 to 3.6.4 to fix vulnerabilities.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
