### PR TITLE
fix: preserve symlinks for libudev

### DIFF
--- a/systemd-udevd/pkg.yaml
+++ b/systemd-udevd/pkg.yaml
@@ -28,7 +28,7 @@ steps:
 
         mkdir -p /rootfs/usr/lib/
         cp -r /installroot/usr/lib/udev /rootfs/usr/lib/
-        cp --preserve=links /installroot/usr/lib/libudev.* /rootfs/usr/lib/
+        cp -d /installroot/usr/lib/libudev.* /rootfs/usr/lib/
         # Already built this
         rm -rf /rootfs/usr/lib/udev/hwdb.d
         rm /rootfs/usr/lib/udev/rules.d/{README,60-cdrom_id.rules,60-persistent-alsa.rules,60-persistent-v4l.rules,64-btrfs.rules,70-joystick.rules,70-mouse.rules,70-touchpad.rules,78-sound-card.rules,90-vconsole.rules,99-systemd.rules}


### PR DESCRIPTION
With `--preserve=links` cp actually turns symlinks into hard links which are lost in the later phases of Talos initramfs build.