### PR TITLE
feat: update libpathrs to 0.2.6

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -175,9 +175,9 @@ vars:
 
   # NOTE: keep in sync with the libpathrs version required by runc: https://github.com/opencontainers/runc/blob/release-1.5/script/build-libpathrs.sh
   # renovate: datasource=github-releases depName=cyphar/libpathrs
-  libpathrs_version: v0.2.5
-  libpathrs_sha256: f8f4a9419eb839cd5decbd120b65f0495bf6eac07155477fe39a8c2a23da589d
-  libpathrs_sha512: 009a6aa91d4ef5ccae011f39def4cf7ffc626fd7def9e9cbcf7c827d813215811719c44674e68192d3f4770c7968f2e7de7c13b27c7e53807f0aa0f4ba5c428f
+  libpathrs_version: v0.2.6
+  libpathrs_sha256: 7b1e3a2c3cc0bd9f94187edbb6d1ba9737deb2bf7f724df1ee37653ea405b2b0
+  libpathrs_sha512: e48a3e2ed8c8403c95621f1f98ae7e95cd86f733894c73478742772852eca2aa52ff99af27e43c2997f3c658cf4f5cb4f86c46c6ec7dcb3b3ddfc3a60797dd17
 
   # renovate: datasource=github-releases extractVersion=^popt-(?<version>.*)-release$ depName=rpm-software-management/popt
   libpopt_version: 1.19


### PR DESCRIPTION
See https://github.com/cyphar/libpathrs/releases/tag/v0.2.6

This seems to have a bugfix for runc specifically.